### PR TITLE
保持ContentProvider初始化顺序和真实环境一致

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/ShadowPluginLoader.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/ShadowPluginLoader.kt
@@ -126,12 +126,10 @@ abstract class ShadowPluginLoader(hostAppContext: Context) : DelegateProvider, D
         fun realAction() {
             val pluginParts = getPluginParts(partKey)
             pluginParts?.let {
-                mPluginContentProviderManager.createContentProviderAndCallOnCreate(
-                        pluginParts.application, partKey, pluginParts)
-            }
-            pluginParts?.let {
                 val application = pluginParts.application
                 application.attachBaseContext(mHostAppContext)
+                mPluginContentProviderManager.createContentProviderAndCallOnCreate(
+                        application, partKey, pluginParts)
                 application.onCreate()
             }
         }


### PR DESCRIPTION
现在：` ConentProvide`r的`onCreate()`方法在`application`的`attachBaseContext`之前调用
希望：`ConentProvide`的`onCreate()`方法在`application`的`attachBaseContext`之后调用, 与真实环境执行顺序一致