### PR TITLE
fix  8.0机器在屏幕旋转的时候由于主题设置透明导致crash

### DIFF
--- a/projects/sample/sample-host/src/main/AndroidManifest.xml
+++ b/projects/sample/sample-host/src/main/AndroidManifest.xml
@@ -99,7 +99,7 @@
             android:name="com.tencent.shadow.sample.host.PluginLoadActivity"
             android:launchMode="standard"
             android:screenOrientation="portrait"
-            android:theme="@style/troop_Transparent" />
+            />
 
         <!--dynamic activity注册
           注意configChanges需要全注册


### PR DESCRIPTION
close #4 插件加载页面可以不设置透明