### PR TITLE
修复4.4.2系统的Dalvik虚拟机MultiDex分包创建文件路径异常的bug

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/blocs/LoadPluginBloc.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/blocs/LoadPluginBloc.kt
@@ -85,6 +85,10 @@ object LoadPluginBloc {
                     File(tempContext.filesDir, "dataDir")
                 }
 
+                if (!dataDir.exists()) {
+                    dataDir.mkdirs()
+                }
+
                 packageArchiveInfo.applicationInfo.nativeLibraryDir = installedApk.libraryPath
                 packageArchiveInfo.applicationInfo.dataDir = dataDir.absolutePath
 
@@ -150,7 +154,6 @@ object LoadPluginBloc {
             return buildRunningPlugin
         }
     }
-
 
 
 }


### PR DESCRIPTION
验证 #49 修复的bug时候发现了该bug，现已经过验证，修复了4.4.2系统的Dalvik虚拟机MultiDex分包创建文件路径异常的bug。 麻烦@shifujun 验证一下。