### PR TITLE
处理数据库升级单元测试在低版本手机上不正常的问题

### DIFF
--- a/projects/sdk/core/manager/src/androidTest/java/com/tencent/shadow/core/manager/installplugin/DbCompatibilityTest.java
+++ b/projects/sdk/core/manager/src/androidTest/java/com/tencent/shadow/core/manager/installplugin/DbCompatibilityTest.java
@@ -19,6 +19,7 @@
 package com.tencent.shadow.core.manager.installplugin;
 
 import android.content.Context;
+import android.os.Build;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -26,6 +27,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.json.JSONException;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,6 +65,11 @@ public class DbCompatibilityTest {
 
     @Before
     public void setUp() {
+        //因为sqlite3本身的bug和版本不一致导致dump结果不一致，这个单元测试只能在Android P上完整正常运行
+        //Android 4.4系统在init时会出现内部错误
+        //Android 7.0系统dump出的sql对表名加了额外的双引号，兼容略麻烦
+        Assume.assumeTrue(Build.VERSION.SDK_INT == Build.VERSION_CODES.P);
+
         context = InstrumentationRegistry.getTargetContext();
         databasePath = context.getDatabasePath(
                 InstalledPluginDBHelper.DB_NAME_PREFIX + TEST_DB_NAME

--- a/projects/sdk/core/manager/src/androidTest/java/com/tencent/shadow/core/manager/installplugin/DbCompatibilityTest.java
+++ b/projects/sdk/core/manager/src/androidTest/java/com/tencent/shadow/core/manager/installplugin/DbCompatibilityTest.java
@@ -201,6 +201,11 @@ public class DbCompatibilityTest {
         if (timeout) {
             throw new TimeoutException("exec超时");
         }
+        int exitValue = p.exitValue();
+        if (exitValue != 0) {
+            String errorOutput = IOUtils.toString(p.getErrorStream(), Charset.defaultCharset());
+            throw new Error("exitValue==" + exitValue + " errorOutput==" + errorOutput);
+        }
     }
 
     /**
@@ -230,6 +235,12 @@ public class DbCompatibilityTest {
 
         if (timeout) {
             throw new TimeoutException("exec超时");
+        }
+
+        int exitValue = p.exitValue();
+        if (exitValue != 0) {
+            String errorOutput = IOUtils.toString(p.getErrorStream(), Charset.defaultCharset());
+            throw new Error("exitValue==" + exitValue + " errorOutput==" + errorOutput);
         }
 
         Assert.assertTrue(dumpSqlFile.exists() && dumpSqlFile.length() > 0);


### PR DESCRIPTION
之前在4.4手机上运行DbCompatibilityTest一直会报错找不到java.lang.Process#waitFor(long, java.util.concurrent.TimeUnit)方法。但是修复之后还是不能正常运行。

经测试发现，Android 4.4手机的sqlite有bug，不能正常用sqlite3 init命令初始化数据库。

后又想兼容更高版本的手机，发现前面说的bug一直到API25都存在。API25中dump出的sql格式又和API28有小差别。而这个单元测试是基于dump出的sql纯文本比较的，因此兼容不同版本sqlite dump出的内容又很麻烦。

因此决定这个单元测试只在Android P上执行。