### PR TITLE
支持白名单书写样式 a.b.c.*

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoader.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoader.kt
@@ -95,14 +95,14 @@ class PluginClassLoader(
     }
 
     private fun String.inPackage(packageNames: Array<String>): Boolean {
-        val packageName = substringBeforeLast('.')
+        val packageName = substringBeforeLast('.', "")
         return packageNames.any {
             if (it.endsWith(".*")) {
-                // because of that it.endsWith('*'),
-                // '*' will always exists in it
-                // the function substringBeforeLast below can use "" for its second parameter
+                // because of that it.endsWith(".*"),  ".*" will always exists in it
+                // if packageNames == [".*"], it will always return true
+                // because every string starts with ""
                 val whiteListPackageName = it.substringBeforeLast(".*")
-                packageName.startsWith(whiteListPackageName)
+                return packageName.startsWith(whiteListPackageName)
             }
             packageName == it
         }

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoader.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoader.kt
@@ -95,14 +95,17 @@ class PluginClassLoader(
     }
 
     private fun String.inPackage(packageNames: Array<String>): Boolean {
-        val packageName: String
-        val dot = lastIndexOf('.')
-        packageName = if (dot != -1) {
-            substring(0, dot)
-        } else {
-            ""
+        val packageName = substringBeforeLast('.')
+        return packageNames.any {
+            if (it.endsWith(".*")) {
+                // because of that it.endsWith('*'),
+                // '*' will always exists in it
+                // the function substringBeforeLast below can use "" for its second parameter
+                val whiteListPackageName = it.substringBeforeLast(".*")
+                packageName.startsWith(whiteListPackageName)
+            }
+            packageName == it
         }
-        return packageNames.any { packageName == it }
     }
 }
 

--- a/projects/sdk/core/loader/src/test/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoaderTest.kt
+++ b/projects/sdk/core/loader/src/test/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoaderTest.kt
@@ -1,0 +1,56 @@
+package com.tencent.shadow.core.loader.classloaders
+
+import org.junit.Assert
+import org.junit.Test
+import java.util.*
+
+/**
+ * @author zby
+ * @email linxy59@mail2.sysu.edu.cn
+ * @date 2019-09-06
+ * @description test String.inPackage(packageNames: Array<String>): Boolean
+ * @usage click icon on the left of testString_inPackage()
+ */
+class PluginClassLoader {
+    @Test
+    fun testString_inPackage() {
+        var packageName = "com.tencent.shadow.core.loader.classloaders.PluginClassLoader"
+        Assert.assertTrue(packageName.inPackage(arrayOf(
+                "com.tencent.shadow.core.loader.classloaders"
+        )))
+        packageName = "com.tencent.shadow.core.loader.classloaders.PluginClassLoader"
+        Assert.assertFalse(packageName.inPackage(arrayOf(
+                ""
+        )))
+        packageName = "com.tencent.shadow.core.loader.classloaders.PluginClassLoader"
+        Assert.assertFalse(packageName.inPackage(arrayOf(
+                "om.tencent.shadow"
+        )))
+
+        //support "a.b.c.*"
+        packageName = "com.tencent.shadow.core.loader.classloaders.PluginClassLoader"
+        Assert.assertTrue(packageName.inPackage(arrayOf(
+                "com.tencent.shadow.*"
+        )))
+        //support ".*" everything can be access
+        packageName = "com.tencent.shadow.core.loader.classloaders.PluginClassLoader"
+        Assert.assertTrue(packageName.inPackage(arrayOf(
+                ".*"
+        )))
+    }
+
+    private fun String.inPackage(packageNames: Array<String>): Boolean {
+        println(this + " in " + Arrays.toString(packageNames))
+        val packageName = substringBeforeLast('.', "")
+        return packageNames.any {
+            if (it.endsWith(".*")) {
+                val whiteListPackageName = it.substringBeforeLast(".*")
+                println("!! [match .*] " + packageName.startsWith(whiteListPackageName))
+                return packageName.startsWith(whiteListPackageName)
+            }
+            println("!! [no match .*] " + (packageName == it))
+            packageName == it
+        }
+    }
+}
+


### PR DESCRIPTION
虽然只暴露了一个类，但是由于是单例模式，调用下去在各个包里乱窜
导致白名单写起来太麻烦了
所以加了个支持
```kotlin
    private fun String.inPackage(packageNames: Array<String>): Boolean {
        val packageName = substringBeforeLast('.')
        return packageNames.any {
            if (it.endsWith(".*")) {
                val whiteListPackageName = it.substringBeforeLast(".*")
                packageName.startsWith(whiteListPackageName)
            }
            packageName == it
        }
    }
```