### PR TITLE
fix it.activities is null

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/managers/PluginPackageManager.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/managers/PluginPackageManager.kt
@@ -60,7 +60,8 @@ class PluginPackageManager(private val hostPackageManager: PackageManager,
     override fun getActivityInfo(component: ComponentName, flags: Int): ActivityInfo {
         if (component.packageName == packageInfo.applicationInfo.packageName) {
             val pluginActivityInfo = allPluginPackageInfo()
-                    .flatMap { it.activities.asIterable() }.find {
+                    .mapNotNull { it.activities }
+                    .flatMap { it.asIterable() }.find {
                         it.name == component.className
                     }
             if (pluginActivityInfo != null) {


### PR DESCRIPTION
最近启动activity遇到crash

![it activities+null](https://user-images.githubusercontent.com/34463867/64417628-0b1f0980-d0cc-11e9-8cd5-be19e1751cad.png)

检查源码发现该处没做非空判断。

根据源码上下文判断，这里会对同一包名的apk遍历所有注册的activity，但我的工程中正好有一个无activity插件，命中了该处错误，建议修复