### PR TITLE
对#108 的逻辑进行补充，完善PluginClassLoader的白名单通配符、单元测试

### DIFF
--- a/projects/sdk/core/loader/build.gradle
+++ b/projects/sdk/core/loader/build.gradle
@@ -35,6 +35,7 @@ android {
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
+        test.java.srcDirs += 'src/test/kotlin'
     }
 }
 

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoader.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoader.kt
@@ -94,18 +94,37 @@ class PluginClassLoader(
         }
     }
 
-    private fun String.inPackage(packageNames: Array<String>): Boolean {
-        val packageName = substringBeforeLast('.', "")
-        return packageNames.any {
-            if (it.endsWith(".*")) {
-                // because of that it.endsWith(".*"),  ".*" will always exists in it
-                // if packageNames == [".*"], it will always return true
-                // because every string starts with ""
-                val whiteListPackageName = it.substringBeforeLast(".*")
-                return packageName.startsWith(whiteListPackageName)
+}
+
+private fun String.subStringBeforeDot() = substringBeforeLast('.', "")
+
+internal fun String.inPackage(packageNames: Array<String>): Boolean {
+    val packageName = subStringBeforeDot()
+
+    return packageNames.any {
+        return when {
+            it == "" -> false
+            it == ".*" -> false
+            it == ".**" -> false
+            it.endsWith(".*") -> {//只允许一级子包
+                val sub = packageName.subStringBeforeDot()
+                return if (sub.isEmpty()) {
+                    false
+                } else {
+                    sub == it.subStringBeforeDot()
+                }
             }
-            packageName == it
+            it.endsWith(".**") -> {//允许所有子包
+                val sub = packageName.subStringBeforeDot()
+                return if (sub.isEmpty()) {
+                    false
+                } else {
+                    sub.startsWith(it.subStringBeforeDot())
+                }
+            }
+            else -> packageName == it
         }
     }
 }
+
 

--- a/projects/sdk/core/loader/src/test/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoaderTest.kt
+++ b/projects/sdk/core/loader/src/test/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoaderTest.kt
@@ -1,8 +1,25 @@
+/*
+ * Tencent is pleased to support the open source community by making Tencent Shadow available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.tencent.shadow.core.loader.classloaders
 
 import org.junit.Assert
 import org.junit.Test
-import java.util.*
 
 /**
  * @author zby
@@ -11,46 +28,147 @@ import java.util.*
  * @description test String.inPackage(packageNames: Array<String>): Boolean
  * @usage click icon on the left of testString_inPackage()
  */
-class PluginClassLoader {
-    @Test
-    fun testString_inPackage() {
-        var packageName = "com.tencent.shadow.core.loader.classloaders.PluginClassLoader"
-        Assert.assertTrue(packageName.inPackage(arrayOf(
-                "com.tencent.shadow.core.loader.classloaders"
-        )))
-        packageName = "com.tencent.shadow.core.loader.classloaders.PluginClassLoader"
-        Assert.assertFalse(packageName.inPackage(arrayOf(
-                ""
-        )))
-        packageName = "com.tencent.shadow.core.loader.classloaders.PluginClassLoader"
-        Assert.assertFalse(packageName.inPackage(arrayOf(
-                "om.tencent.shadow"
-        )))
+class PluginClassLoaderTest {
 
-        //support "a.b.c.*"
-        packageName = "com.tencent.shadow.core.loader.classloaders.PluginClassLoader"
-        Assert.assertTrue(packageName.inPackage(arrayOf(
-                "com.tencent.shadow.*"
-        )))
-        //support ".*" everything can be access
-        packageName = "com.tencent.shadow.core.loader.classloaders.PluginClassLoader"
-        Assert.assertTrue(packageName.inPackage(arrayOf(
-                ".*"
-        )))
+    @Test
+    fun case11() {
+        val packageNames = arrayOf("a.b.c")
+        val className = "a.b.c.D"
+        Assert.assertTrue(className.inPackage(packageNames))
     }
 
-    private fun String.inPackage(packageNames: Array<String>): Boolean {
-        println(this + " in " + Arrays.toString(packageNames))
-        val packageName = substringBeforeLast('.', "")
-        return packageNames.any {
-            if (it.endsWith(".*")) {
-                val whiteListPackageName = it.substringBeforeLast(".*")
-                println("!! [match .*] " + packageName.startsWith(whiteListPackageName))
-                return packageName.startsWith(whiteListPackageName)
-            }
-            println("!! [no match .*] " + (packageName == it))
-            packageName == it
-        }
+    @Test
+    fun case12() {
+        val packageNames = arrayOf("a.b.c")
+        val className = "a.b.D"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case13() {
+        val packageNames = arrayOf("a.b.c")
+        val className = "a.b.c"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case14() {
+        val packageNames = arrayOf("a.b.c")
+        val className = "a.b.c.d.E"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case21() {
+        val packageNames = arrayOf("")
+        val className = "A"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case22() {
+        val packageNames = arrayOf("")
+        val className = "a.B"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case31() {
+        val packageNames = arrayOf("b.c")
+        val className = "a.b.c.D"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case41() {
+        val packageNames = arrayOf("a.b.c.*")
+        val className = "a.b.c.D"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case42() {
+        val packageNames = arrayOf("a.b.c.*")
+        val className = "a.b.c"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case43() {
+        val packageNames = arrayOf("a.b.c.*")
+        val className = "a.b.c.d.E"
+        Assert.assertTrue(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case44() {
+        val packageNames = arrayOf("a.b.c.*")
+        val className = "a.b.c.d.e.F"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case51() {
+        val packageNames = arrayOf(".*")
+        val className = "a.b.c.d.E"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case52() {
+        val packageNames = arrayOf(".*")
+        val className = "A"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case61() {
+        val packageNames = arrayOf("a.b.c.**")
+        val className = "a.b.c.D"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case62() {
+        val packageNames = arrayOf("a.b.c.**")
+        val className = "a.b.c.d.E"
+        Assert.assertTrue(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case63() {
+        val packageNames = arrayOf("a.b.c.**")
+        val className = "a.b.c.d.e.F"
+        Assert.assertTrue(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case64() {
+        val packageNames = arrayOf("a.b.c.**")
+        val className = "a.b.C"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case65() {
+        val packageNames = arrayOf(".**")
+        val className = "a.b.c.D"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case66() {
+        val packageNames = arrayOf(".**")
+        val className = "a.B"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case67() {
+        val packageNames = arrayOf(".**")
+        val className = "A"
+        Assert.assertFalse(className.inPackage(packageNames))
     }
 }
+
 


### PR DESCRIPTION
对原有白名单逻辑没有改动。声明"a.b.c",意味着所有包名是"a.b.c"的类处于白名单中。
改动#108 中引入的"a.b.c.*"的含义。
声明"a.b.c.*"意味着目标类的包名也是3个点分隔的4段。
再新增一种"a.b.c.**"的语法，表示目标类的包名至少有3个点，至少分隔成4段，
还包括更多层级。
对"",".*",".**"三种容易产生误解的场景，直接返回false。