### PR TITLE
fix(loader):initPluginActivity时最后调用setHostContextAsBase

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
@@ -150,7 +150,6 @@ class ShadowActivityDelegate(private val mDI: DI) : HostActivityDelegate, Shadow
     private fun initPluginActivity(pluginActivity: PluginActivity) {
         pluginActivity.setHostActivityDelegator(mHostActivityDelegator)
         pluginActivity.setPluginResources(mPluginResources)
-        pluginActivity.setHostContextAsBase(mHostActivityDelegator.hostActivity as Context)
         pluginActivity.setPluginClassLoader(mPluginClassLoader)
         pluginActivity.setPluginComponentLauncher(mComponentManager)
         pluginActivity.setPluginApplication(mPluginApplication)
@@ -158,6 +157,13 @@ class ShadowActivityDelegate(private val mDI: DI) : HostActivityDelegate, Shadow
         pluginActivity.applicationInfo = mPluginApplication.applicationInfo
         pluginActivity.setBusinessName(mBusinessName)
         pluginActivity.setPluginPartKey(mPartKey)
+
+        //前面的所有set方法都是PluginActivity定义的方法，
+        //业务的Activity子类不会覆盖这些方法。调用它们不会执行业务Activity的任何逻辑。
+        //最后这个setHostContextAsBase会调用插件Activity的attachBaseContext方法，
+        //有可能会执行业务Activity覆盖的逻辑。
+        //所以，这个调用要放在最后。
+        pluginActivity.setHostContextAsBase(mHostActivityDelegator.hostActivity as Context)
     }
 
     override fun onResume() {

--- a/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/ApplicationContextInActivityTest.java
+++ b/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/ApplicationContextInActivityTest.java
@@ -1,0 +1,51 @@
+/*
+ * Tencent is pleased to support the open source community by making Tencent Shadow available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.tencent.shadow.test.cases.plugin_main;
+
+import android.content.Intent;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class ApplicationContextInActivityTest extends PluginMainAppTest {
+
+    @Override
+    protected Intent getLaunchIntent() {
+        Intent pluginIntent = new Intent();
+        String packageName = ApplicationProvider.getApplicationContext().getPackageName();
+        pluginIntent.setClassName(
+                packageName,
+                "com.tencent.shadow.test.plugin.general_cases.lib.usecases.activity.ApplicationContextActivity"
+        );
+        return pluginIntent;
+    }
+
+    @Test
+    public void testUseApplicationContextInAttachBaseContext() {
+        matchTextWithViewTag("noError", Boolean.toString(true));
+    }
+
+}

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/AndroidManifest.xml
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/AndroidManifest.xml
@@ -73,6 +73,7 @@
 
         <activity android:name=".usecases.context.ApplicationContextSubDirTestActivity" />
         <activity android:name=".usecases.application.TestGetApplicationInfoActivity" />
+        <activity android:name=".usecases.activity.ApplicationContextActivity" />
 
         <provider
             android:authorities="com.tencent.shadow.provider.test"

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/activity/ApplicationContextActivity.java
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/activity/ApplicationContextActivity.java
@@ -1,0 +1,29 @@
+package com.tencent.shadow.test.plugin.general_cases.lib.usecases.activity;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.widget.TextView;
+
+public class ApplicationContextActivity extends Activity {
+
+    private boolean noError = false;
+
+    @Override
+    protected void attachBaseContext(Context newBase) {
+        super.attachBaseContext(newBase);
+        Context applicationContext = getApplicationContext();
+        noError = applicationContext != null;
+    }
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        TextView textView = new TextView(this);
+        textView.setText(Boolean.toString(noError));
+        textView.setTag("noError");
+        setContentView(textView);
+    }
+}


### PR DESCRIPTION
initPluginActivity中只有setHostContextAsBase会触发对插件Activity对象的调用，即attachBaseContext。而插件在attachBaseContext中有可能调用getApplicationContext方法。修复前getApplicationContext方法会返回null。