### PR TITLE
feat: 支持AndroidX(#154)

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/ShadowPluginLoader.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/ShadowPluginLoader.kt
@@ -190,6 +190,7 @@ abstract class ShadowPluginLoader(hostAppContext: Context) : DelegateProvider, D
             if (pluginParts == null) {
                 throw IllegalStateException("partKey==${partKey}在map中找不到。此时map：${mPluginPartsMap}")
             } else {
+                delegate.inject(pluginParts.appComponentFactory)
                 delegate.inject(pluginParts.application)
                 delegate.inject(pluginParts.classLoader)
                 delegate.inject(pluginParts.resources)

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/blocs/CreateApplicationBloc.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/blocs/CreateApplicationBloc.kt
@@ -25,6 +25,7 @@ import com.tencent.shadow.core.loader.classloaders.PluginClassLoader
 import com.tencent.shadow.core.loader.exceptions.CreateApplicationException
 import com.tencent.shadow.core.loader.infos.PluginInfo
 import com.tencent.shadow.core.loader.managers.ComponentManager
+import com.tencent.shadow.core.runtime.ShadowAppComponentFactory
 import com.tencent.shadow.core.runtime.ShadowApplication
 
 /**
@@ -40,23 +41,20 @@ object CreateApplicationBloc {
             resources: Resources,
             hostAppContext: Context,
             componentManager: ComponentManager,
-            applicationInfo: ApplicationInfo
+            applicationInfo: ApplicationInfo,
+            appComponentFactory: ShadowAppComponentFactory
     ): ShadowApplication {
         try {
             val appClassName = pluginInfo.applicationClassName
-            val shadowApplication : ShadowApplication;
-            shadowApplication = if (appClassName != null) {
-                val appClass = pluginClassLoader.loadClass(appClassName)
-                ShadowApplication::class.java.cast(appClass.newInstance())
-            } else {
-                object : ShadowApplication(){}
-            }
+                    ?: ShadowApplication::class.java.name
+            val shadowApplication = appComponentFactory.instantiateApplication(pluginClassLoader, appClassName)
             val partKey = pluginInfo.partKey
             shadowApplication.setPluginResources(resources)
             shadowApplication.setPluginClassLoader(pluginClassLoader)
             shadowApplication.setPluginComponentLauncher(componentManager)
             shadowApplication.setHostApplicationContextAsBase(hostAppContext)
             shadowApplication.setBroadcasts(componentManager.getBroadcastsByPartKey(partKey))
+            shadowApplication.setAppComponentFactory(appComponentFactory)
             shadowApplication.applicationInfo = applicationInfo
             shadowApplication.setBusinessName(pluginInfo.businessName)
             shadowApplication.setPluginPartKey(partKey)

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/blocs/ParsePluginApkBloc.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/blocs/ParsePluginApkBloc.kt
@@ -20,6 +20,7 @@ package com.tencent.shadow.core.loader.blocs
 
 import android.content.Context
 import android.content.pm.PackageInfo
+import android.os.Build
 import com.tencent.shadow.core.load_parameters.LoadParameters
 import com.tencent.shadow.core.loader.exceptions.ParsePluginApkException
 import com.tencent.shadow.core.loader.infos.PluginActivityInfo
@@ -74,6 +75,9 @@ object ParsePluginApkBloc {
                 , packageArchiveInfo.applicationInfo.packageName
                 , packageArchiveInfo.applicationInfo.className
         )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            pluginInfo.appComponentFactory = packageArchiveInfo.applicationInfo.appComponentFactory
+        }
         packageArchiveInfo.activities?.forEach {
             pluginInfo.putActivityInfo(PluginActivityInfo(it.name, it.themeResource, it))
         }

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
@@ -416,4 +416,12 @@ class ShadowActivityDelegate(private val mDI: DI) : HostActivityDelegate, Shadow
     override fun onTitleChanged(title: CharSequence?, color: Int) {
         mPluginActivity.onTitleChanged(title, color)
     }
+
+    override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean) {
+        mPluginActivity.onPictureInPictureModeChanged(isInPictureInPictureMode)
+    }
+
+    override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration?) {
+        mPluginActivity.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+    }
 }

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
@@ -117,8 +117,11 @@ class ShadowActivityDelegate(private val mDI: DI) : HostActivityDelegate, Shadow
 
         mHostActivityDelegator.setTheme(pluginActivityInfo.themeResource)
         try {
-            val aClass = mPluginClassLoader.loadClass(pluginActivityClassName)
-            val pluginActivity = PluginActivity::class.java.cast(aClass.newInstance())
+            val pluginActivity = mAppComponentFactory.instantiateActivity(
+                    mPluginClassLoader,
+                    pluginActivityClassName,
+                    mHostActivityDelegator.intent
+            )
             initPluginActivity(pluginActivity)
             mPluginActivity = pluginActivity
 

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
@@ -424,4 +424,8 @@ class ShadowActivityDelegate(private val mDI: DI) : HostActivityDelegate, Shadow
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration?) {
         mPluginActivity.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
     }
+
+    override fun onStateNotSaved() {
+        mPluginActivity.onStateNotSaved()
+    }
 }

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
@@ -412,4 +412,8 @@ class ShadowActivityDelegate(private val mDI: DI) : HostActivityDelegate, Shadow
     override fun onPostResume() {
         mPluginActivity.onPostResume()
     }
+
+    override fun onTitleChanged(title: CharSequence?, color: Int) {
+        mPluginActivity.onTitleChanged(title, color)
+    }
 }

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowDelegate.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowDelegate.kt
@@ -21,12 +21,17 @@ package com.tencent.shadow.core.loader.delegates
 import android.content.res.Resources
 import com.tencent.shadow.core.loader.classloaders.PluginClassLoader
 import com.tencent.shadow.core.loader.managers.ComponentManager
+import com.tencent.shadow.core.runtime.ShadowAppComponentFactory
 import com.tencent.shadow.core.runtime.ShadowApplication
 
 abstract class ShadowDelegate() {
 
     fun inject(shadowApplication: ShadowApplication) {
         _pluginApplication = shadowApplication
+    }
+
+    fun inject(appComponentFactory: ShadowAppComponentFactory) {
+        _appComponentFactory = appComponentFactory
     }
 
     fun inject(pluginClassLoader: PluginClassLoader) {
@@ -41,11 +46,14 @@ abstract class ShadowDelegate() {
         _componentManager = componentManager
     }
 
+    private lateinit var _appComponentFactory: ShadowAppComponentFactory
     private lateinit var _pluginApplication: ShadowApplication
     private lateinit var _pluginClassLoader: PluginClassLoader
     private lateinit var _pluginResources: Resources
     private lateinit var _componentManager: ComponentManager
 
+    protected val mAppComponentFactory: ShadowAppComponentFactory
+        get() = _appComponentFactory
     protected val mPluginApplication: ShadowApplication
         get() = _pluginApplication
     protected val mPluginClassLoader: PluginClassLoader

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/infos/PluginInfo.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/infos/PluginInfo.kt
@@ -34,6 +34,7 @@ class PluginInfo(
     internal val mProviders: Set<PluginProviderInfo>
         get() = _mProviders
 
+    internal var appComponentFactory: String? = null
 
     fun putActivityInfo(pluginActivityInfo: PluginActivityInfo) {
         _mActivities.add(pluginActivityInfo)

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/infos/PluginParts.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/infos/PluginParts.kt
@@ -21,11 +21,14 @@ package com.tencent.shadow.core.loader.infos
 import android.content.res.Resources
 import com.tencent.shadow.core.loader.classloaders.PluginClassLoader
 import com.tencent.shadow.core.runtime.PluginPackageManager
+import com.tencent.shadow.core.runtime.ShadowAppComponentFactory
 import com.tencent.shadow.core.runtime.ShadowApplication
 
-class PluginParts(val application: ShadowApplication,
-                  val classLoader: PluginClassLoader,
-                  val resources: Resources,
-                  val businessName: String?,
-                  val pluginPackageManager: PluginPackageManager
+class PluginParts(
+        val appComponentFactory: ShadowAppComponentFactory,
+        val application: ShadowApplication,
+        val classLoader: PluginClassLoader,
+        val resources: Resources,
+        val businessName: String?,
+        val pluginPackageManager: PluginPackageManager
 )

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/managers/PluginContentProviderManager.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/managers/PluginContentProviderManager.kt
@@ -26,7 +26,7 @@ import com.tencent.shadow.core.loader.infos.ContainerProviderInfo
 import com.tencent.shadow.core.loader.infos.PluginParts
 import com.tencent.shadow.core.loader.infos.PluginProviderInfo
 import com.tencent.shadow.core.runtime.UriParseDelegate
-import java.util.HashMap
+import java.util.*
 import kotlin.collections.HashSet
 import kotlin.collections.set
 
@@ -85,8 +85,8 @@ class PluginContentProviderManager() : UriParseDelegate {
     fun createContentProviderAndCallOnCreate(mContext: Context, partKey: String, pluginParts: PluginParts?) {
         pluginProviderInfoMap[partKey]?.forEach {
             try {
-                val clz = pluginParts!!.classLoader.loadClass(it.className)
-                val contentProvider = ContentProvider::class.java.cast(clz.newInstance())
+                val contentProvider = pluginParts!!.appComponentFactory
+                        .instantiateProvider(pluginParts.classLoader, it.className)
                 contentProvider?.attachInfo(mContext, it.providerInfo)
                 providerMap[it.authority] = contentProvider
             } catch (e: Exception) {

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginActivity.java
@@ -370,4 +370,8 @@ public abstract class PluginActivity extends ShadowContext implements Window.Cal
     public void onPictureInPictureModeChanged(boolean inPictureInPictureMode, Configuration newConfig) {
         mHostActivityDelegator.superOnPictureInPictureModeChanged(inPictureInPictureMode, newConfig);
     }
+
+    public void onStateNotSaved() {
+        mHostActivityDelegator.superOnStateNotSaved();
+    }
 }

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginActivity.java
@@ -99,6 +99,10 @@ public abstract class PluginActivity extends ShadowContext implements Window.Cal
         mHostActivityDelegator.superOnConfigurationChanged(newConfig);
     }
 
+    public void onTitleChanged(CharSequence title, int color) {
+        mHostActivityDelegator.superOnTitleChanged(title, color);
+    }
+
     public boolean dispatchKeyEvent(KeyEvent event) {
         return mHostActivityDelegator.superDispatchKeyEvent(event);
     }

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginActivity.java
@@ -362,4 +362,12 @@ public abstract class PluginActivity extends ShadowContext implements Window.Cal
     public void onPostResume() {
         mHostActivityDelegator.superOnPostResume();
     }
+
+    public void onPictureInPictureModeChanged(boolean inPictureInPictureMode) {
+        mHostActivityDelegator.superOnPictureInPictureModeChanged(inPictureInPictureMode);
+    }
+
+    public void onPictureInPictureModeChanged(boolean inPictureInPictureMode, Configuration newConfig) {
+        mHostActivityDelegator.superOnPictureInPictureModeChanged(inPictureInPictureMode, newConfig);
+    }
 }

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginFragmentManager.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginFragmentManager.java
@@ -23,6 +23,7 @@ import android.annotation.TargetApi;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.os.Build;
+import android.os.Bundle;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -65,5 +66,10 @@ public class PluginFragmentManager {
             }
         }
         return pluginFragments.size() > 0 ? pluginFragments : Collections.EMPTY_LIST;
+    }
+
+    public ShadowFragment getFragment(Bundle bundle, String key) {
+        Fragment fragment = mBase.getFragment(bundle, key);
+        return ((IContainerFragment) fragment).getPluginFragment();
     }
 }

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowActivity.java
@@ -345,4 +345,12 @@ public abstract class ShadowActivity extends PluginActivity {
     public void dump(String prefix, FileDescriptor fd, PrintWriter writer, String[] args) {
         mHostActivityDelegator.superDump(prefix, fd, writer, args);
     }
+
+    public final <T extends View> T requireViewById(int id) {
+        T view = findViewById(id);
+        if (view == null) {
+            throw new IllegalArgumentException("ID does not reference a View inside this Activity");
+        }
+        return view;
+    }
 }

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowActivity.java
@@ -38,6 +38,9 @@ import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
 
+import java.io.FileDescriptor;
+import java.io.PrintWriter;
+
 public abstract class ShadowActivity extends PluginActivity {
 
     private int mFragmentManagerHash;
@@ -337,5 +340,9 @@ public abstract class ShadowActivity extends PluginActivity {
 
     public void closeOptionsMenu() {
         mHostActivityDelegator.superCloseOptionsMenu();
+    }
+
+    public void dump(String prefix, FileDescriptor fd, PrintWriter writer, String[] args) {
+        mHostActivityDelegator.superDump(prefix, fd, writer, args);
     }
 }

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowActivity.java
@@ -330,4 +330,12 @@ public abstract class ShadowActivity extends PluginActivity {
     public void setTheme(int resid) {
         mHostActivityDelegator.setTheme(resid);
     }
+
+    public void openOptionsMenu() {
+        mHostActivityDelegator.superOpenOptionsMenu();
+    }
+
+    public void closeOptionsMenu() {
+        mHostActivityDelegator.superCloseOptionsMenu();
+    }
 }

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowAppComponentFactory.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowAppComponentFactory.java
@@ -1,0 +1,38 @@
+package com.tencent.shadow.core.runtime;
+
+import android.content.BroadcastReceiver;
+import android.content.ContentProvider;
+import android.content.Intent;
+
+public class ShadowAppComponentFactory {
+
+    public ShadowApplication instantiateApplication(ClassLoader cl,
+                                                    String className)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        return (ShadowApplication) cl.loadClass(className).newInstance();
+    }
+
+    public ShadowActivity instantiateActivity(ClassLoader cl, String className,
+                                              Intent intent)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        return (ShadowActivity) cl.loadClass(className).newInstance();
+    }
+
+    public BroadcastReceiver instantiateReceiver(ClassLoader cl,
+                                                 String className, Intent intent)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        return (BroadcastReceiver) cl.loadClass(className).newInstance();
+    }
+
+    public ShadowService instantiateService(ClassLoader cl,
+                                            String className, Intent intent)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        return (ShadowService) cl.loadClass(className).newInstance();
+    }
+
+    public ContentProvider instantiateProvider(ClassLoader cl,
+                                               String className)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        return (ContentProvider) cl.loadClass(className).newInstance();
+    }
+}

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowApplication.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowApplication.java
@@ -41,6 +41,8 @@ public abstract class ShadowApplication extends ShadowContext {
 
     private Map<String, List<String>> mBroadcasts;
 
+    private ShadowAppComponentFactory mAppComponentFactory;
+
     public boolean isCallOnCreate;
 
     @Override
@@ -58,6 +60,8 @@ public abstract class ShadowApplication extends ShadowContext {
             try {
                 Class<?> clazz = mPluginClassLoader.loadClass(entry.getKey());
                 BroadcastReceiver receiver = ((BroadcastReceiver) clazz.newInstance());
+                mAppComponentFactory.instantiateReceiver(mPluginClassLoader, entry.getKey(), null);
+
                 IntentFilter intentFilter = new IntentFilter();
                 for (String action:entry.getValue()
                      ) {
@@ -157,5 +161,9 @@ public abstract class ShadowApplication extends ShadowContext {
 
     public void attachBaseContext(Context base) {
         //do nothing.
+    }
+
+    public void setAppComponentFactory(ShadowAppComponentFactory factory) {
+        mAppComponentFactory = factory;
     }
 }

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowFragment.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowFragment.java
@@ -19,6 +19,7 @@
 package com.tencent.shadow.core.runtime;
 
 import android.animation.Animator;
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Fragment;
@@ -590,4 +591,9 @@ public class ShadowFragment {
         mContainerFragment.requestPermissions(permissions, requestCode);
     }
 
+    @SuppressLint("NewApi")
+    final public ShadowFragment getParentFragment() {
+        Fragment parentFragment = mContainerFragment.asFragment().getParentFragment();
+        return ((IContainerFragment) parentFragment).getPluginFragment();
+    }
 }

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowService.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowService.java
@@ -25,6 +25,9 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.IBinder;
 
+import java.io.FileDescriptor;
+import java.io.PrintWriter;
+
 /**
  * Created by tracyluo on 2018/6/5.
  */
@@ -120,5 +123,9 @@ public abstract class ShadowService extends ShadowContext {
 
     public final ShadowApplication getApplication() {
         return mShadowApplication;
+    }
+
+    protected void dump(FileDescriptor fd, PrintWriter writer, String[] args) {
+        writer.println("nothing to dump");
     }
 }

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/container/HostActivityDelegate.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/container/HostActivityDelegate.java
@@ -158,4 +158,6 @@ public interface HostActivityDelegate {
     void onPictureInPictureModeChanged(boolean isInPictureInPictureMode);
 
     void onPictureInPictureModeChanged(boolean isInPictureInPictureMode, Configuration newConfig);
+
+    void onStateNotSaved();
 }

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/container/HostActivityDelegate.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/container/HostActivityDelegate.java
@@ -152,4 +152,6 @@ public interface HostActivityDelegate {
     void onMultiWindowModeChanged(boolean isInMultiWindowMode, Configuration newConfig);
 
     void onPostResume();
+
+    void onTitleChanged(CharSequence title, int color);
 }

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/container/HostActivityDelegate.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/container/HostActivityDelegate.java
@@ -154,4 +154,8 @@ public interface HostActivityDelegate {
     void onPostResume();
 
     void onTitleChanged(CharSequence title, int color);
+
+    void onPictureInPictureModeChanged(boolean isInPictureInPictureMode);
+
+    void onPictureInPictureModeChanged(boolean isInPictureInPictureMode, Configuration newConfig);
 }

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/container/HostActivityDelegator.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/container/HostActivityDelegator.java
@@ -252,10 +252,6 @@ public interface HostActivityDelegator {
 
     void invalidateOptionsMenu();
 
-    void openOptionsMenu();
-
-    void closeOptionsMenu();
-
     void registerForContextMenu(View view);
 
     void unregisterForContextMenu(View view);

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerActivity.java
@@ -311,6 +311,24 @@ public class PluginContainerActivity extends Activity implements HostActivity, H
     }
 
     @Override
+    public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode) {
+        if (hostActivityDelegate != null) {
+            hostActivityDelegate.onPictureInPictureModeChanged(isInPictureInPictureMode);
+        } else {
+            super.onPictureInPictureModeChanged(isInPictureInPictureMode);
+        }
+    }
+
+    @Override
+    public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode, Configuration newConfig) {
+        if (hostActivityDelegate != null) {
+            hostActivityDelegate.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig);
+        } else {
+            super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig);
+        }
+    }
+
+    @Override
     public void finish() {
         if (hostActivityDelegate != null) {
             hostActivityDelegate.finish();

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerActivity.java
@@ -302,6 +302,15 @@ public class PluginContainerActivity extends Activity implements HostActivity, H
     }
 
     @Override
+    protected void onTitleChanged(CharSequence title, int color) {
+        if (hostActivityDelegate != null) {
+            hostActivityDelegate.onTitleChanged(title, color);
+        } else {
+            super.onTitleChanged(title, color);
+        }
+    }
+
+    @Override
     public void finish() {
         if (hostActivityDelegate != null) {
             hostActivityDelegate.finish();

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerActivity.java
@@ -383,6 +383,15 @@ public class PluginContainerActivity extends Activity implements HostActivity, H
     }
 
     @Override
+    public void onStateNotSaved() {
+        if (hostActivityDelegate != null) {
+            hostActivityDelegate.onStateNotSaved();
+        } else {
+            super.onStateNotSaved();
+        }
+    }
+
+    @Override
     protected void onUserLeaveHint() {
         if (hostActivityDelegate != null) {
             hostActivityDelegate.onUserLeaveHint();

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/TransformManager.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/TransformManager.kt
@@ -41,6 +41,7 @@ class TransformManager(ctClassInputMap: Map<CtClass, InputClass>,
             ContentProviderTransform(),
             PackageManagerTransform(),
             PackageItemInfoTransform(),
+            AppComponentFactoryTransform(),
             KeepHostContextTransform(useHostContext())
     )
 }

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/AppComponentFactoryTransform.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/AppComponentFactoryTransform.kt
@@ -1,0 +1,8 @@
+package com.tencent.shadow.core.transform.specific
+
+class AppComponentFactoryTransform : SimpleRenameTransform(
+        mapOf(
+                "android.app.AppComponentFactory"
+                        to "com.tencent.shadow.core.runtime.ShadowAppComponentFactory"
+        )
+)


### PR DESCRIPTION
通过编写了两种Transform逻辑，我检查出了目前AndroidX所依赖的，但是Shadow缺失的方法。不过Transform检查的逻辑在一些场景下还存在误判，可能会阻塞插件的编译，因此待解决后再合入。

补充这些实现后，我相信AndroidX是完整支持了。看起来我们没有做什么，实际上也是正常的，因为AndroidX将大部分系统类的实现都重新实现了，比如Activity、Fragment，这些类在Shadow已经属于插件的代码了。而它们对系统原有类的依赖又很少，比如不可替代的Activity的生命周期方法，Shadow很容易就支持了。可以说，如果直接使用系统类在Shadow中工作不正常，可以转而使用AndroidX的实现。

现在可以认为 #154 的问题解决了。

close #163 
close #164 
close #165 