### PR TITLE
transform-kit添加修改被调用类后的检查能力

### DIFF
--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransform.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransform.kt
@@ -19,7 +19,13 @@
 package com.tencent.shadow.core.transform_kit
 
 import com.android.build.api.transform.TransformInvocation
+import javassist.ClassPool
+import javassist.CtClass
 import org.gradle.api.Project
+import java.io.*
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 abstract class AbstractTransform(
         project: Project,
@@ -27,10 +33,19 @@ abstract class AbstractTransform(
 ) : JavassistTransform(project, classPoolBuilder) {
 
     protected abstract val mTransformManager: AbstractTransformManager
+    private val mDebugClassJar = File(project.buildDir, "transform-temp.jar")
+    private lateinit var mDebugClassJarZOS: ZipOutputStream
+
+
+    private fun cleanDebugClassFileDir() {
+        mDebugClassJar.delete()
+        mDebugClassJarZOS = ZipOutputStream(FileOutputStream(mDebugClassJar))
+    }
 
     override fun beforeTransform(invocation: TransformInvocation) {
         super.beforeTransform(invocation)
         ReplaceClassName.resetErrorCount()
+        cleanDebugClassFileDir()
     }
 
     override fun onTransform() {
@@ -41,10 +56,82 @@ abstract class AbstractTransform(
     override fun afterTransform(invocation: TransformInvocation) {
         super.afterTransform(invocation)
 
-        val errorCount = ReplaceClassName.getErrorCount()
-        if (errorCount > 0) {
-            throw IllegalStateException("存在${errorCount}处方法未实现的问题，需要Shadow补充实现。详见前面输出的Log")
+        mDebugClassJarZOS.flush()
+        mDebugClassJarZOS.close()
+
+        //CtClass在编辑后，其对象中的各种信息，比如superClass并没有更新。
+        //所以需要重新创建一个ClassPool，加载转换后的类，用于各种转换后的检查。
+        val debugClassPool = classPoolBuilder.build()
+        debugClassPool.appendClassPath(mDebugClassJar.absolutePath)
+        val inputClassNames = mCtClassInputMap.keys.map { it.name }
+        onCheckTransformedClasses(debugClassPool, inputClassNames)
+    }
+
+    override fun onOutputClass(className: String, outputStream: OutputStream) {
+        classPool[className].debugWriteJar(mDebugClassJarZOS)
+        super.onOutputClass(className, outputStream)
+    }
+
+    private fun CtClass.debugWriteJar(outputStream: ZipOutputStream) {
+        try {
+            val entryName = (name.replace('.', '/') + ".class")
+            outputStream.putNextEntry(ZipEntry(entryName))
+            val p = stopPruning(true)
+            toBytecode(DataOutputStream(outputStream))
+            defrost()
+            stopPruning(p)
+        } catch (e: Exception) {
+            outputStream.close()
+            throw RuntimeException(e)
         }
     }
 
+    open fun onCheckTransformedClasses(debugClassPool: ClassPool, classNames: List<String>) {
+        var delayException: Exception? = null
+        val start1 = System.currentTimeMillis()
+        try {
+            checkReplacedClassHaveRightMethods(debugClassPool, classNames)
+        } catch (e: Exception) {
+            if (delayException == null) {
+                delayException = e
+            } else {
+                delayException.addSuppressed(e)
+            }
+        }
+        project.logger.info("checkReplacedClassHaveRightMethods完毕，耗时(ms):${System.currentTimeMillis() - start1}")
+
+        if (delayException != null) {
+            throw delayException
+        }
+    }
+
+    /**
+     * 检查转换后的类，其中被替换了的类有实现被调用的方法
+     */
+    private fun checkReplacedClassHaveRightMethods(debugClassPool: ClassPool, classNames: List<String>) {
+        val result = ReplaceClassName.checkAll(debugClassPool, classNames)
+        if (result.isNotEmpty()) {
+            val tempFile = File.createTempFile("shadow_replace_class_have_right_methods", ".txt", project.buildDir)
+            val bw = BufferedWriter(FileWriter(tempFile))
+
+            result.forEach {
+                val defClass = it.key
+                bw.appendln("Class ${defClass}中缺少方法:")
+                val methodMap = it.value
+                methodMap.forEach {
+                    val methodString = it.key
+                    val useClass = it.value
+
+                    bw.appendln("${methodString}被这些类调用了:")
+                    useClass.forEach {
+                        bw.appendln(it)
+                    }
+                }
+                bw.newLine()
+            }
+            bw.flush()
+            bw.close()
+            throw IllegalStateException("存在转换后被调用方法未实现的问题，详见${tempFile.absolutePath}")
+        }
+    }
 }

--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/OverrideCheck.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/OverrideCheck.kt
@@ -1,0 +1,126 @@
+package com.tencent.shadow.core.transform_kit
+
+import com.android.build.gradle.internal.utils.toImmutableMap
+import javassist.ClassPool
+import javassist.CtClass
+import javassist.CtMethod
+import javassist.NotFoundException
+
+typealias Method_OriginalDeclaringClass = Pair<CtMethod, String>
+
+class OverrideCheck {
+    /**
+     * key:Transform前的类名
+     * value：Override的方法
+     */
+    private val methodMap: MutableMap<String, Collection<Method_OriginalDeclaringClass>> = hashMapOf()
+
+    /**
+     * 这个map用于应对Transform后类名变化的情况
+     * Transform后，check时，从CtClass取出新类名
+     *
+     * key:Transform前的类名
+     * value: CtClass
+     */
+    private val ctClassMap: MutableMap<String, CtClass> = hashMapOf()
+
+    fun prepare(inputClasses: Set<CtClass>) {
+        methodMap.clear()
+        ctClassMap.clear()
+
+        inputClasses.filter {
+            //kotlinx里有一些方法的覆盖检查不出来，反正我们也不改它，就不检查了。
+            it.packageName.startsWith("kotlinx").not()
+        }.filter {
+            try {
+                it.methods
+                it.superclass
+                true
+            } catch (e: NotFoundException) {
+                false
+            }
+        }.forEach { clazz ->
+            val name = clazz.name
+            try {
+                methodMap[name] = clazz.findAllOverrideMethods()
+                ctClassMap[name] = clazz
+            } catch (e: Exception) {
+                throw RuntimeException("处理${name}时发生错误", e)
+            }
+        }
+    }
+
+    fun makeNewNameToOldNameMap(): HashMap<String, String> {
+        val newNameToOldName = hashMapOf<String, String>()
+        ctClassMap.forEach {
+            newNameToOldName[it.value.name] = it.key
+        }
+        return newNameToOldName
+    }
+
+    fun getOverrideMethods() = methodMap.toImmutableMap()
+
+    fun check(debugClassPool: ClassPool, classNames: List<String>): Map<String, List<Method_OriginalDeclaringClass>> {
+        val newNameToOldName = makeNewNameToOldNameMap()
+
+        val errorResult: HashMap<String, MutableList<Method_OriginalDeclaringClass>> = hashMapOf()
+        classNames.filter {
+            it.startsWith("kotlinx").not()
+        }.filter {
+            val clazz = debugClassPool[it]!!
+            try {
+                clazz.methods
+                clazz.superclass
+                true
+            } catch (e: NotFoundException) {
+                false
+            }
+        }.forEach { className ->
+            try {
+                val oldName = newNameToOldName[className]!!
+                val methods = methodMap[oldName]!!
+                val clazz = debugClassPool[className]!!
+                methods.forEach {
+                    val isOverride = clazz.isMethodOverride(it.first)
+                    if (!isOverride) {
+                        var list = errorResult[className]
+                        if (list == null) {
+                            list = mutableListOf()
+                            errorResult[className] = list
+                        }
+                        list.add(it)
+                    }
+                }
+            } catch (e: RuntimeException) {
+                throw RuntimeException("className==$className", e)
+            }
+
+        }
+        return errorResult
+    }
+
+    companion object {
+        private fun CtClass.findAllOverrideMethods(): List<Pair<CtMethod, String>> {
+            val methodsDeclaredInClass = mutableListOf<Pair<CtMethod, String>>()
+            declaredMethods.forEach {
+                try {
+                    val methodOfSuperClass = superclass.getMethod(it.name, it.signature)
+                    methodsDeclaredInClass.add(it to methodOfSuperClass.declaringClass.name)
+                } catch (ignored: NotFoundException) {
+                }
+            }
+            return methodsDeclaredInClass
+        }
+
+        private fun CtClass.hasSameMethod(m: CtMethod) =
+                try {
+                    getMethod(m.name, m.signature)
+                    true
+                } catch (ignored: NotFoundException) {
+                    false
+                }
+
+        private fun CtClass.isMethodOverride(originMethod: CtMethod) =
+                superclass.hasSameMethod(originMethod)
+    }
+}

--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/ReplaceClassName.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/ReplaceClassName.kt
@@ -25,15 +25,14 @@ import javassist.expr.ExprEditor
 import javassist.expr.MethodCall
 
 object ReplaceClassName {
-    private var mErrorCount = 0
-    private val mNewNames = mutableListOf<String>()
+    private val mNewNames = mutableSetOf<String>()
+    /**
+     * MutableMap<defClass, MutableMap<method, MutableSet<useClass>>>
+     */
+    private val errorResult: MutableMap<String, MutableMap<String, MutableSet<String>>> = mutableMapOf()
 
     fun resetErrorCount() {
-        mErrorCount = 0
-    }
-
-    fun getErrorCount(): Int {
-        return mErrorCount
+        errorResult.clear()
     }
 
     fun replaceClassName(ctClass: CtClass, oldName: String, newName: String) {
@@ -41,12 +40,16 @@ object ReplaceClassName {
         mNewNames.add(newName)
     }
 
-    fun checkAll(classPool: ClassPool, classes: Set<CtClass>) {
-        classes.forEach { ctClass ->
-            mNewNames.forEach { newName ->
-                ctClass.checkMethodExist(classPool[newName])
+    fun checkAll(classPool: ClassPool, inputClassNames: List<String>): Map<String, Map<String, Set<String>>> {
+        inputClassNames.forEach { inputClassName ->
+            val inputClass = classPool[inputClassName]
+            if (inputClass.refClasses.any { mNewNames.contains(it) }) {
+                mNewNames.forEach { newName ->
+                    inputClass.checkMethodExist(classPool[newName])
+                }
             }
         }
+        return errorResult
     }
 
     /**
@@ -54,15 +57,25 @@ object ReplaceClassName {
      */
     private fun CtClass.checkMethodExist(refClass: CtClass) {
         val invokeClass = name
+        val refClassName = refClass.name
         instrument(object : ExprEditor() {
             override fun edit(m: MethodCall) {
-                if (m.className == refClass.name) {
+                if (m.className == refClassName) {
                     try {
                         refClass.getMethod(m.methodName, m.signature)
                     } catch (ignored: NotFoundException) {
-                        mErrorCount++
-                        System.err.println("类$invokeClass 调用类${refClass.name}的" +
-                                "方法m.methodName==${m.methodName} 签名m.signature==${m.signature}不存在")
+                        val methodString = "${m.methodName}:${m.signature}"
+                        var methodMap = errorResult[refClassName]
+                        if (methodMap == null) {
+                            methodMap = mutableMapOf()
+                            errorResult[refClassName] = methodMap
+                        }
+                        var useSet = methodMap[methodString]
+                        if (useSet == null) {
+                            useSet = mutableSetOf()
+                            methodMap[methodString] = useSet
+                        }
+                        useSet.add(invokeClass)
                     }
                 }
             }

--- a/projects/sdk/core/transform-kit/src/test/java/test/override/Foo.java
+++ b/projects/sdk/core/transform-kit/src/test/java/test/override/Foo.java
@@ -1,0 +1,70 @@
+package test.override;
+
+class ArgBase {
+
+}
+
+class Arg extends ArgBase {
+
+}
+
+class NewArg extends ArgBase {
+
+}
+
+class SuperSuper {
+    protected void ss1() {
+
+    }
+}
+
+class Super extends SuperSuper {
+    protected void s1(Arg arg) {
+
+    }
+
+    protected void s2(Arg arg) {
+
+    }
+}
+
+class NewSuper extends SuperSuper {
+    protected void s1(NewArg newArg) {
+
+    }
+}
+
+class Foo extends Super {
+
+    @Override
+    protected void ss1() {
+        super.ss1();
+    }
+
+    @Override
+    protected void s1(Arg arg) {
+        super.s1(arg);
+    }
+
+    @Override
+    protected void s2(Arg arg) {
+        super.s2(arg);
+    }
+}
+
+class Bar extends Foo {
+    @Override
+    protected void ss1() {
+        super.ss1();
+    }
+
+    @Override
+    protected void s1(Arg arg) {
+        super.s1(arg);
+    }
+
+    @Override
+    protected void s2(Arg arg) {
+        super.s2(arg);
+    }
+}

--- a/projects/sdk/core/transform-kit/src/test/kotlin/com/tencent/shadow/core/transform_kit/OverrideCheckTest.kt
+++ b/projects/sdk/core/transform-kit/src/test/kotlin/com/tencent/shadow/core/transform_kit/OverrideCheckTest.kt
@@ -1,0 +1,91 @@
+package com.tencent.shadow.core.transform_kit
+
+import javassist.ClassPool
+import javassist.CtClass
+import org.apache.commons.io.FileUtils
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+class OverrideCheckTest : AbstractTransformTest() {
+    private lateinit var inputClasses: Array<CtClass>
+    private val overrideCheck = OverrideCheck()
+    private lateinit var overrideMap: Map<String, Collection<Method_OriginalDeclaringClass>>
+    private lateinit var errorResult: Map<String, List<Method_OriginalDeclaringClass>>
+
+    @Before
+    fun setUp() {
+        FileUtils.cleanDirectory(File(WRITE_FILE_DIR))
+        inputClasses = ClassPool(true).get(arrayOf(
+                "test.override.Bar",
+                "test.override.Foo"
+        ))
+        overrideCheck.prepare(inputClasses.toSet())
+        overrideMap = overrideCheck.getOverrideMethods()
+        replaceClass(inputClasses)
+        errorResult = overrideCheck.check(dLoader, inputClasses.map { it.name })
+    }
+
+    private fun replaceClass(inputClasses: Array<CtClass>) {
+        inputClasses.forEach {
+            it.replaceClassName("test.override.Foo", "test.override.Foo_")
+            it.replaceClassName("test.override.Arg", "test.override.NewArg")
+            it.replaceClassName("test.override.Super", "test.override.NewSuper")
+            it.writeFile(WRITE_FILE_DIR)
+        }
+    }
+
+    @Test
+    fun testFooFindAll() {
+        val name = "test.override.Foo"
+        findAllOverrideMethods(name)
+    }
+
+    @Test
+    fun testFooFindError() {
+        val name = "test.override.Foo_"
+        Assert.assertTrue(errorResult.contains(name))
+        val error = errorResult[name]!!
+        Assert.assertEquals(1, error.size)
+        Assert.assertTrue(
+                error.any {
+                    it.first.name == "s2"
+                }
+        )
+    }
+
+    @Test
+    fun testBarFindAll() {
+        val name = "test.override.Bar"
+        findAllOverrideMethods(name)
+    }
+
+    @Test
+    fun testBarFindError() {
+        val name = "test.override.Bar"
+        Assert.assertFalse(errorResult.contains(name))
+    }
+
+    private fun findAllOverrideMethods(name: String) {
+        val overrideMethods = overrideMap[name]!!
+        Assert.assertTrue(
+                overrideMethods.any {
+                    it.first.name == "ss1"
+                }
+        )
+
+        Assert.assertTrue(
+                overrideMethods.any {
+                    it.first.name == "s1"
+                }
+        )
+
+        Assert.assertTrue(
+                overrideMethods.any {
+                    it.first.name == "s2"
+                }
+        )
+    }
+
+}


### PR DESCRIPTION
在Transform中会将插件中的一些调用转移到Runtime的中间层来。但是中间件层可能实现的不完整，导致一些插件原本调用系统方法的地方工作不正常。有两种情况，调用方法不存在，或者系统调用来的回调接收不到。

因此添加两种检查：
1. 在Transform后检查替换的类是否实现了被调用的方法
2.检查Transform前后Override的方法是否在父类中还存在

这个检查可以帮助确定Shadow是否支持这个插件所需的全部功能。