### PR TITLE
fix(core.runtime): 修复ResourcesWrapper在构造器中调用updateConfiguration会Crash的问题

### DIFF
--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ResourcesWrapper.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ResourcesWrapper.java
@@ -288,4 +288,12 @@ public class ResourcesWrapper extends Resources {
     public void parseBundleExtra(String tagName, AttributeSet attrs, Bundle outBundle) throws XmlPullParserException {
         mBase.parseBundleExtra(tagName, attrs, outBundle);
     }
+
+    @Override
+    public void updateConfiguration(Configuration config, DisplayMetrics metrics) {
+        super.updateConfiguration(config, metrics);
+        if (mBase != null) { // called from super's constructor. So, need to check.
+            mBase.updateConfiguration(config, metrics);
+        }
+    }
 }


### PR DESCRIPTION
参考support包实现
http://aospxref.com/android-6.0.0_r41/xref/frameworks/support/v7/appcompat/src/android/support/v7/internal/widget/ResourcesWrapper.java#228