### PR TITLE
fix(): 修复白名单匹配规则，防止提早return掉

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoader.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoader.kt
@@ -108,7 +108,7 @@ internal fun String.inPackage(packageNames: Array<String>): Boolean {
             it == ".**" -> false
             it.endsWith(".*") -> {//只允许一级子包
                 val sub = packageName.subStringBeforeDot()
-                return if (sub.isEmpty()) {
+                if (sub.isEmpty()) {
                     false
                 } else {
                     sub == it.subStringBeforeDot()
@@ -116,7 +116,7 @@ internal fun String.inPackage(packageNames: Array<String>): Boolean {
             }
             it.endsWith(".**") -> {//允许所有子包
                 val sub = packageName.subStringBeforeDot()
-                return if (sub.isEmpty()) {
+                if (sub.isEmpty()) {
                     false
                 } else {
                     sub.startsWith(it.subStringBeforeDot())

--- a/projects/sdk/core/loader/src/test/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoaderTest.kt
+++ b/projects/sdk/core/loader/src/test/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoaderTest.kt
@@ -183,6 +183,13 @@ class PluginClassLoaderTest {
         val className = "A"
         Assert.assertFalse(className.inPackage(packageNames))
     }
+
+    @Test
+    fun case68() {
+        val packageNames = arrayOf("a.b.c.d.**", "a.b.c2.d2.**")
+        val className = "a.b.c2.d2.e2.F"
+        Assert.assertTrue(className.inPackage(packageNames))
+    }
 }
 
 


### PR DESCRIPTION
解决当出现a.b.c.d.**，却又不匹配(a.b.c2.d2.e2.F)时，导致提早return false 结束判断