### PR TITLE
fix(core.runtime): 修复插件没有自定义Application时Crash的问题

### DIFF
--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowApplication.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowApplication.java
@@ -35,7 +35,7 @@ import java.util.Map;
 /**
  * 用于在plugin-loader中调用假的Application方法的接口
  */
-public abstract class ShadowApplication extends ShadowContext {
+public class ShadowApplication extends ShadowContext {
 
     private Application mHostApplication;
 


### PR DESCRIPTION
ShadowApplication作为默认Application类不能是抽象类。

fix #177