### PR TITLE
演示 supportActionBar.setDisplayHomeAsUpEnabled 点击事件失效

### DIFF
--- a/projects/sample/sunflower/plugin-project/app/src/main/java/com/google/samples/apps/sunflower/GardenActivity.kt
+++ b/projects/sample/sunflower/plugin-project/app/src/main/java/com/google/samples/apps/sunflower/GardenActivity.kt
@@ -16,6 +16,7 @@
 
 package com.google.samples.apps.sunflower
 
+import android.view.MenuItem
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil.setContentView
@@ -26,5 +27,15 @@ class GardenActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView<ActivityGardenBinding>(this, R.layout.activity_garden)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
+        val id = item?.itemId
+        return if (id == android.R.id.home) {
+            onBackPressed()
+            true
+        } else {
+            super.onOptionsItemSelected(item)
+        }
     }
 }

--- a/projects/sample/sunflower/plugin-project/app/src/main/java/com/google/samples/apps/sunflower/HomeViewPagerFragment.kt
+++ b/projects/sample/sunflower/plugin-project/app/src/main/java/com/google/samples/apps/sunflower/HomeViewPagerFragment.kt
@@ -48,6 +48,7 @@ class HomeViewPagerFragment : Fragment() {
         }.attach()
 
         (activity as AppCompatActivity).setSupportActionBar(binding.toolbar)
+        (activity as AppCompatActivity).supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         return binding.root
     }


### PR DESCRIPTION
在 ```android/sunflower```项目中加上以上代码，```Actionbar```出现返回键，点击可以正常返回。
在 Shadow 的 sample 中则点击事件失效。