### PR TITLE
feat(core.activity-container): 支持onOptionsItemSelected

### DIFF
--- a/projects/sdk/core/activity-container/src/main/java/com/tencent/shadow/core/runtime/container/HostActivityDelegate.java
+++ b/projects/sdk/core/activity-container/src/main/java/com/tencent/shadow/core/runtime/container/HostActivityDelegate.java
@@ -33,6 +33,7 @@ import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
+import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.WindowManager;
@@ -160,4 +161,6 @@ public interface HostActivityDelegate {
     void onPictureInPictureModeChanged(boolean isInPictureInPictureMode, Configuration newConfig);
 
     void onStateNotSaved();
+
+    boolean onOptionsItemSelected(MenuItem item);
 }

--- a/projects/sdk/core/activity-container/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerActivity.java
+++ b/projects/sdk/core/activity-container/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerActivity.java
@@ -2237,4 +2237,13 @@ public class PluginContainerActivity extends Activity implements HostActivity, H
             super.onMultiWindowModeChanged(isInMultiWindowMode, newConfig);
         }
     }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (hostActivityDelegate != null) {
+            return hostActivityDelegate.onOptionsItemSelected(item);
+        } else {
+            return super.onOptionsItemSelected(item);
+        }
+    }
 }

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
@@ -428,4 +428,8 @@ class ShadowActivityDelegate(private val mDI: DI) : HostActivityDelegate, Shadow
     override fun onStateNotSaved() {
         mPluginActivity.onStateNotSaved()
     }
+
+    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
+        return mPluginActivity.onOptionsItemSelected(item)
+    }
 }


### PR DESCRIPTION
之前PluginActivity中的onOptionsItemSelected方法没有被调用过，但是却实现了，导致OverrideCheck没有检查出来。

fix #183