### PR TITLE
fix(core.loader): 修复PluginClassLoader白名单匹配时部分匹配的问题

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoader.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoader.kt
@@ -124,7 +124,7 @@ internal fun String.inPackage(packageNames: Array<String>): Boolean {
                 if (sub.isEmpty()) {
                     false
                 } else {
-                    sub.startsWith(it.subStringBeforeDot())
+                    "$sub.".startsWith(it.subStringBeforeDot() + '.')
                 }
             }
             else -> packageName == it

--- a/projects/sdk/core/loader/src/test/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoaderTest.kt
+++ b/projects/sdk/core/loader/src/test/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoaderTest.kt
@@ -190,6 +190,34 @@ class PluginClassLoaderTest {
         val className = "a.b.c2.d2.e2.F"
         Assert.assertTrue(className.inPackage(packageNames))
     }
+
+    @Test
+    fun case71() {
+        val packageNames = arrayOf("com.tencent.**")
+        val className = "com.tencentshadow.MyClass"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case72() {
+        val packageNames = arrayOf("com.tencent.**")
+        val className = "com.tencentshadow.next.MyClass"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case73() {
+        val packageNames = arrayOf("com.tencent**")
+        val className = "com.tencentshadow.MyClass"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
+
+    @Test
+    fun case74() {
+        val packageNames = arrayOf("com.tencent**")
+        val className = "com.tencentshadow.next.MyClass"
+        Assert.assertFalse(className.inPackage(packageNames))
+    }
 }
 
 


### PR DESCRIPTION
新增的测试用例caes72在修复前是失败的。