### PR TITLE
test: sample中补充插件应该compileOnly方式依赖runtime

### DIFF
--- a/projects/sample/maven/plugin-project/plugin-shadow-apk/build.gradle
+++ b/projects/sample/maven/plugin-project/plugin-shadow-apk/build.gradle
@@ -8,6 +8,12 @@ android {
     }
 }
 
+dependencies {
+    //Shadow Transform后业务代码会有一部分实际引用runtime中的类
+    //如果不以compileOnly方式依赖，会导致其他Transform或者Proguard找不到这些类
+    compileOnly "com.tencent.shadow.core:runtime:$shadow_version"
+}
+
 //这段buildscript配置的dependencies是为了apply plugin: 'com.tencent.shadow.plugin'能找到实现
 buildscript {
     repositories {

--- a/projects/sample/source/sample-plugin/sample-plugin-app/build.gradle
+++ b/projects/sample/source/sample-plugin/sample-plugin-app/build.gradle
@@ -6,6 +6,12 @@ android {
     }
 }
 
+dependencies {
+    //Shadow Transform后业务代码会有一部分实际引用runtime中的类
+    //如果不以compileOnly方式依赖，会导致其他Transform或者Proguard找不到这些类
+    compileOnly 'com.tencent.shadow.core:runtime-debug'
+}
+
 buildscript {
     repositories {
         google()

--- a/projects/sample/sunflower/plugin-project/app/build.gradle
+++ b/projects/sample/sunflower/plugin-project/app/build.gradle
@@ -51,6 +51,10 @@ android {
 }
 
 dependencies {
+    //Shadow Transform后业务代码会有一部分实际引用runtime中的类
+    //如果不以compileOnly方式依赖，会导致其他Transform或者Proguard找不到这些类
+    compileOnly "com.tencent.shadow.core:runtime:$shadow_version"
+
     kapt "androidx.room:room-compiler:$rootProject.roomVersion"
     kapt "com.github.bumptech.glide:compiler:$rootProject.glideVersion"
     implementation "androidx.appcompat:appcompat:$rootProject.appCompatVersion"


### PR DESCRIPTION
否则构建过程中一些其他Transform或者Proguard要找Shadow的runtime类时会报错，或者Proguard规则不生效。

fix #189