### PR TITLE
feat(activity-container): DelegateProviderHolder支持多DelegateProvider

### DIFF
--- a/projects/sample/source/sample-plugin/sample-loader/src/main/java/com/tencent/shadow/sample/plugin/loader/SamplePluginLoader.java
+++ b/projects/sample/source/sample-plugin/sample-loader/src/main/java/com/tencent/shadow/sample/plugin/loader/SamplePluginLoader.java
@@ -80,4 +80,9 @@ public class SamplePluginLoader extends ShadowPluginLoader {
 
         return future;
     }
+
+    @Override
+    public String getDelegateProviderKey() {
+        return "SAMPLE";
+    }
 }

--- a/projects/sample/source/sample-plugin/sample-runtime/src/main/java/com/tencent/shadow/sample/plugin/runtime/PluginDefaultProxyActivity.java
+++ b/projects/sample/source/sample-plugin/sample-runtime/src/main/java/com/tencent/shadow/sample/plugin/runtime/PluginDefaultProxyActivity.java
@@ -25,4 +25,9 @@ import com.tencent.shadow.core.runtime.container.PluginContainerActivity;
 
 @SuppressLint("Registered")//无需注册在这个模块的Manifest中，要注册在宿主的Manifest中。
 public class PluginDefaultProxyActivity extends PluginContainerActivity {
+
+    @Override
+    protected String getDelegateProviderKey() {
+        return "SAMPLE";
+    }
 }

--- a/projects/sdk/core/activity-container/src/main/java/com/tencent/shadow/core/runtime/container/DelegateProviderHolder.java
+++ b/projects/sdk/core/activity-container/src/main/java/com/tencent/shadow/core/runtime/container/DelegateProviderHolder.java
@@ -21,6 +21,9 @@ package com.tencent.shadow.core.runtime.container;
 
 import android.os.SystemClock;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * DelegateProvider依赖注入类
  * <p>
@@ -29,7 +32,8 @@ import android.os.SystemClock;
  * @author cubershi
  */
 public class DelegateProviderHolder {
-    private static DelegateProvider delegateProvider;
+    public static final String DEFAULT_KEY = "DEFAULT_KEY";
+    private static Map<String, DelegateProvider> delegateProviderMap = new HashMap<>();
 
     /**
      * 为了防止系统有一定概率出现进程号重启后一致的问题，我们使用开机时间作为进程号来判断进程是否重启
@@ -40,12 +44,11 @@ public class DelegateProviderHolder {
         sCustomPid = SystemClock.elapsedRealtime();
     }
 
-
-    public static void setDelegateProvider(DelegateProvider delegateProvider) {
-        DelegateProviderHolder.delegateProvider = delegateProvider;
+    public static void setDelegateProvider(String key, DelegateProvider delegateProvider) {
+        delegateProviderMap.put(key, delegateProvider);
     }
 
-    public static DelegateProvider getDelegateProvider() {
-        return delegateProvider;
+    public static DelegateProvider getDelegateProvider(String key) {
+        return delegateProviderMap.get(key);
     }
 }

--- a/projects/sdk/core/activity-container/src/main/java/com/tencent/shadow/core/runtime/container/HostActivityDelegate.java
+++ b/projects/sdk/core/activity-container/src/main/java/com/tencent/shadow/core/runtime/container/HostActivityDelegate.java
@@ -48,6 +48,8 @@ import android.view.WindowManager;
 public interface HostActivityDelegate {
     void setDelegator(HostActivityDelegator delegator);
 
+    String getLoaderVersion();
+
     Object getPluginActivity();
 
     void onCreate(Bundle savedInstanceState);

--- a/projects/sdk/core/activity-container/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerActivity.java
+++ b/projects/sdk/core/activity-container/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerActivity.java
@@ -117,7 +117,7 @@ public class PluginContainerActivity extends Activity implements HostActivity, H
 
     public PluginContainerActivity() {
         HostActivityDelegate delegate;
-        DelegateProvider delegateProvider = DelegateProviderHolder.getDelegateProvider();
+        DelegateProvider delegateProvider = DelegateProviderHolder.getDelegateProvider(getDelegateProviderKey());
         if (delegateProvider != null) {
             delegate = delegateProvider.getHostActivityDelegate(this.getClass());
             delegate.setDelegator(this);
@@ -126,6 +126,10 @@ public class PluginContainerActivity extends Activity implements HostActivity, H
             delegate = null;
         }
         hostActivityDelegate = delegate;
+    }
+
+    protected String getDelegateProviderKey() {
+        return DelegateProviderHolder.DEFAULT_KEY;
     }
 
     final public Object getPluginActivity() {

--- a/projects/sdk/core/activity-container/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerActivity.java
+++ b/projects/sdk/core/activity-container/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerActivity.java
@@ -87,8 +87,6 @@ import android.view.WindowManager;
 import android.view.accessibility.AccessibilityEvent;
 import android.widget.Toolbar;
 
-import com.tencent.shadow.core.container.BuildConfig;
-
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
@@ -184,7 +182,7 @@ public class PluginContainerActivity extends Activity implements HostActivity, H
         try {
             String loaderVersion = bundle.getString(LOADER_VERSION_KEY);
             long processVersion = bundle.getLong(PROCESS_ID_KEY);
-            return !BuildConfig.VERSION_NAME.equals(loaderVersion) || processVersion != DelegateProviderHolder.sCustomPid;
+            return !hostActivityDelegate.getLoaderVersion().equals(loaderVersion) || processVersion != DelegateProviderHolder.sCustomPid;
         } catch (Throwable ignored) {
             //捕获可能的非法Intent中包含我们根本反序列化不了的数据
             return true;
@@ -217,7 +215,7 @@ public class PluginContainerActivity extends Activity implements HostActivity, H
             super.onSaveInstanceState(outState);
         }
         //避免插件setIntent清空掉LOADER_VERSION_KEY
-        outState.putString(LOADER_VERSION_KEY, BuildConfig.VERSION_NAME);
+        outState.putString(LOADER_VERSION_KEY, hostActivityDelegate.getLoaderVersion());
         outState.putLong(PROCESS_ID_KEY, DelegateProviderHolder.sCustomPid);
     }
 

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/ShadowPluginLoader.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/ShadowPluginLoader.kt
@@ -48,6 +48,8 @@ abstract class ShadowPluginLoader(hostAppContext: Context) : DelegateProvider, D
 
     protected val mExecutorService = Executors.newCachedThreadPool()
 
+    open val delegateProviderKey: String = DelegateProviderHolder.DEFAULT_KEY
+
     /**
      * loadPlugin方法是在子线程被调用的。而getHostActivityDelegate方法是在主线程被调用的。
      * 两个方法需要传递数据（主要是PluginParts），因此需要同步。

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
@@ -34,6 +34,7 @@ import android.os.Bundle
 import android.util.AttributeSet
 import android.view.*
 import com.tencent.shadow.core.common.LoggerFactory
+import com.tencent.shadow.core.loader.BuildConfig
 import com.tencent.shadow.core.loader.infos.PluginActivityInfo
 import com.tencent.shadow.core.loader.managers.ComponentManager.Companion.CM_ACTIVITY_INFO_KEY
 import com.tencent.shadow.core.loader.managers.ComponentManager.Companion.CM_BUSINESS_NAME_KEY
@@ -168,6 +169,8 @@ class ShadowActivityDelegate(private val mDI: DI) : HostActivityDelegate, Shadow
         //所以，这个调用要放在最后。
         pluginActivity.setHostContextAsBase(mHostActivityDelegator.hostActivity as Context)
     }
+
+    override fun getLoaderVersion() = BuildConfig.VERSION_NAME
 
     override fun onResume() {
         mPluginActivity.onResume()

--- a/projects/sdk/dynamic/dynamic-loader-impl/src/main/kotlin/com/tencent/shadow/dynamic/loader/impl/DynamicPluginLoader.kt
+++ b/projects/sdk/dynamic/dynamic-loader-impl/src/main/kotlin/com/tencent/shadow/dynamic/loader/impl/DynamicPluginLoader.kt
@@ -66,7 +66,7 @@ internal class DynamicPluginLoader(hostContext: Context, uuid: String) {
                     CORE_LOADER_FACTORY_IMPL_NAME
             )
             mPluginLoader = coreLoaderFactory.build(hostContext)
-            DelegateProviderHolder.setDelegateProvider(mPluginLoader)
+            DelegateProviderHolder.setDelegateProvider(mPluginLoader.delegateProviderKey, mPluginLoader)
             ContentProviderDelegateProviderHolder.setContentProviderDelegateProvider(mPluginLoader)
             mPluginLoader.onCreate()
         } catch (e: Exception) {

--- a/projects/test/none-dynamic/host/test-none-dynamic-host/src/main/java/com/tencent/shadow/test/none_dynamic/host/HostApplication.java
+++ b/projects/test/none-dynamic/host/test-none-dynamic-host/src/main/java/com/tencent/shadow/test/none_dynamic/host/HostApplication.java
@@ -93,7 +93,7 @@ public class HostApplication extends Application {
 
         ShadowPluginLoader loader = mPluginLoader = new TestPluginLoader(getApplicationContext());
         loader.onCreate();
-        DelegateProviderHolder.setDelegateProvider(loader);
+        DelegateProviderHolder.setDelegateProvider(loader.getDelegateProviderKey(), loader);
         ContentProviderDelegateProviderHolder.setContentProviderDelegateProvider(loader);
 
         InstalledApk installedApk = sPluginPrepareBloc.preparePlugin(this.getApplicationContext());


### PR DESCRIPTION
示例中的loader和runtime虽然是分别hardcode的key，但是也可以很容易的改成再共同依赖一个新模块定义这个key，或者通过Gradle生成BuildConfig字段来设置。

这个功能是内部两个业务想在同一个进程都使用Shadow而引入的。对于没有这个需求的业务来说，也不受影响。