### PR TITLE
Fix override check

### DIFF
--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/OverrideCheck.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/OverrideCheck.kt
@@ -112,7 +112,7 @@ class OverrideCheck {
             val methodsDeclaredInClass = mutableListOf<Pair<CtMethod, String>>()
             declaredMethods.forEach {
                 try {
-                    val methodOfSuperClass = superclass.getMethod(it.name, it.signature)
+                    val methodOfSuperClass = superclass.getMethod(it.name, it.genericSignature)
                     methodsDeclaredInClass.add(it to methodOfSuperClass.declaringClass.name)
                 } catch (ignored: NotFoundException) {
                 }
@@ -122,7 +122,7 @@ class OverrideCheck {
 
         private fun CtClass.hasSameMethod(m: CtMethod) =
                 try {
-                    getMethod(m.name, m.signature)
+                    getMethod(m.name, m.genericSignature)
                     true
                 } catch (ignored: NotFoundException) {
                     false

--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/OverrideCheck.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/OverrideCheck.kt
@@ -32,7 +32,9 @@ class OverrideCheck {
         methodMap.clear()
         ctClassMap.clear()
 
-        inputClasses.filter {
+        inputClasses
+                .filter { it.packageName != null }
+                .filter {
             //kotlinx里有一些方法的覆盖检查不出来，反正我们也不改它，就不检查了。
             it.packageName.isKotlinClass().not()
         }.filter {
@@ -68,7 +70,9 @@ class OverrideCheck {
         val newNameToOldName = makeNewNameToOldNameMap()
 
         val errorResult: HashMap<String, MutableList<Method_OriginalDeclaringClass>> = hashMapOf()
-        classNames.filter {
+        classNames
+                .filter { it.contains(".") }
+                .filter {
             it.isKotlinClass().not()
         }.filter {
             val clazz = debugClassPool[it]!!


### PR DESCRIPTION
测试插件implementation 'com.google.code.gson:gson:2.8.6'时，OverrideCheck会误报。

修复发现的两处问题。