### PR TITLE
修复host-multi-loader-ext的发布脚本错误问题

### DIFF
--- a/buildScripts/gradle/maven.gradle
+++ b/buildScripts/gradle/maven.gradle
@@ -295,7 +295,7 @@ publishing {
                 def root = asNode()
                 def dependencies = root.appendNode('dependencies')
                 dependencies.append(getDependencyNode('compile', coreGroupId, 'common', publicationVersion))
-                dependencies.append(getDependencyNode('compile', dynamicGroupId, 'dynamic-host', publicationVersion))
+                dependencies.append(getDependencyNode('compile', dynamicGroupId, 'host', publicationVersion))
 
                 def scm = root.appendNode('scm')
                 setScm(scm)


### PR DESCRIPTION
host-multi-loader-ext的依赖误写成dynamic-host