### PR TITLE
test: 去掉非公开SDK接口调用检查的penaltyDeath

### DIFF
--- a/projects/sample/source/sample-host/src/main/java/com/tencent/shadow/sample/host/HostApplication.java
+++ b/projects/sample/source/sample-host/src/main/java/com/tencent/shadow/sample/host/HostApplication.java
@@ -65,7 +65,6 @@ public class HostApplication extends Application {
             return;
         }
         StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder();
-        builder.penaltyDeath();
         builder.detectNonSdkApiUsage();
         StrictMode.setVmPolicy(builder.build());
     }

--- a/projects/test/dynamic/host/test-dynamic-host/src/main/java/com/tencent/shadow/test/dynamic/host/HostApplication.java
+++ b/projects/test/dynamic/host/test-dynamic-host/src/main/java/com/tencent/shadow/test/dynamic/host/HostApplication.java
@@ -69,7 +69,6 @@ public class HostApplication extends Application {
             return;
         }
         StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder();
-        builder.penaltyDeath();
         builder.detectNonSdkApiUsage();
         StrictMode.setVmPolicy(builder.build());
     }

--- a/projects/test/none-dynamic/host/test-none-dynamic-host/src/main/java/com/tencent/shadow/test/none_dynamic/host/HostApplication.java
+++ b/projects/test/none-dynamic/host/test-none-dynamic-host/src/main/java/com/tencent/shadow/test/none_dynamic/host/HostApplication.java
@@ -115,7 +115,6 @@ public class HostApplication extends Application {
             return;
         }
         StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder();
-        builder.penaltyDeath();
         builder.detectNonSdkApiUsage();
         StrictMode.setVmPolicy(builder.build());
     }


### PR DESCRIPTION
fb2da721 对WebView添加了调用。而WebView中包含非公开SDK接口调用。具体为：
Accessing hidden method Landroid/view/textclassifier/logging/SmartSelectionEventTracker;-><init>(Landroid/content/Context;I)V (light greylist, reflection)

fix #217
fix #206
fix #198