### PR TITLE
fix(activity-container): 添加API23，24引入的类型的假定义，使API22可以正常启动

### DIFF
--- a/projects/sdk/core/activity-container/src/main/java/android/app/assist/AssistContent.java
+++ b/projects/sdk/core/activity-container/src/main/java/android/app/assist/AssistContent.java
@@ -1,0 +1,5 @@
+package android.app.assist;
+
+//避免API 23以下系统找不到这个类
+public interface AssistContent {
+}

--- a/projects/sdk/core/activity-container/src/main/java/android/view/SearchEvent.java
+++ b/projects/sdk/core/activity-container/src/main/java/android/view/SearchEvent.java
@@ -1,0 +1,5 @@
+package android.view;
+
+//避免API 23以下系统找不到这个类
+public interface SearchEvent {
+}

--- a/projects/sdk/core/activity-container/src/main/java/java/util/function/Consumer.java
+++ b/projects/sdk/core/activity-container/src/main/java/java/util/function/Consumer.java
@@ -1,0 +1,5 @@
+package java.util.function;
+
+//避免API 24以下系统找不到这个类
+public interface Consumer<T> {
+}


### PR DESCRIPTION
Activity在新版本上添加的新接口带有一些新版本才引入的系统类。这些类在低版本系统上找不到，会导致Crash。通过定义假的类定义，可以使ClassLoader在BootClassLoader找不到类定义时也能找到一个假的定义。由于这些方法在低版本系统上本来就不工作，所以假定义可以满足需求。

#230(部分解决）