### PR TITLE
fix(activity-container): 添加API21引入的类型的假定义

### DIFF
--- a/projects/sdk/core/activity-container/src/main/java/android/app/ActivityManager.java
+++ b/projects/sdk/core/activity-container/src/main/java/android/app/ActivityManager.java
@@ -1,0 +1,7 @@
+package android.app;
+
+public interface ActivityManager {
+    //避免API 21以下系统找不到这个类
+    interface TaskDescription {
+    }
+}

--- a/projects/sdk/core/activity-container/src/main/java/android/app/SharedElementCallback.java
+++ b/projects/sdk/core/activity-container/src/main/java/android/app/SharedElementCallback.java
@@ -1,0 +1,5 @@
+package android.app;
+
+//避免API 21以下系统找不到这个类
+public interface SharedElementCallback {
+}

--- a/projects/sdk/core/activity-container/src/main/java/android/media/session/MediaController.java
+++ b/projects/sdk/core/activity-container/src/main/java/android/media/session/MediaController.java
@@ -1,0 +1,5 @@
+package android.media.session;
+
+//避免API 21以下系统找不到这个类
+public interface MediaController {
+}

--- a/projects/sdk/core/activity-container/src/main/java/android/os/PersistableBundle.java
+++ b/projects/sdk/core/activity-container/src/main/java/android/os/PersistableBundle.java
@@ -1,0 +1,5 @@
+package android.os;
+
+//避免API 21以下系统找不到这个类
+public interface PersistableBundle {
+}

--- a/projects/sdk/core/activity-container/src/main/java/android/transition/TransitionManager.java
+++ b/projects/sdk/core/activity-container/src/main/java/android/transition/TransitionManager.java
@@ -1,0 +1,5 @@
+package android.transition;
+
+//避免API 19以下系统找不到这个类
+public interface TransitionManager {
+}

--- a/projects/sdk/core/activity-container/src/main/java/android/widget/Toolbar.java
+++ b/projects/sdk/core/activity-container/src/main/java/android/widget/Toolbar.java
@@ -1,0 +1,5 @@
+package android.widget;
+
+//避免API 21以下系统找不到这个类
+public interface Toolbar {
+}


### PR DESCRIPTION
通过https://developer.android.com/sdk/api_diff/21/changes找出新增的接口涉及的新类型

#230

现在API19的虚拟机可以正常启动了。