### PR TITLE
使用Multiprocess由PPS决定插件所在进程并增加sample

### DIFF
--- a/projects/sample/source/sample-constant/src/main/java/com/tencent/shadow/sample/constant/Constant.java
+++ b/projects/sample/source/sample-constant/src/main/java/com/tencent/shadow/sample/constant/Constant.java
@@ -24,6 +24,8 @@ final public class Constant {
     public static final String KEY_EXTRAS = "KEY_EXTRAS";
     public static final String KEY_PLUGIN_PART_KEY = "KEY_PLUGIN_PART_KEY";
     public static final String PART_KEY_PLUGIN_MAIN_APP = "sample-plugin-app";
+    public static final String PART_KEY_PLUGIN_ANOTHER_APP = "sample-plugin-app2";
+
     public static final int FROM_ID_NOOP = 1000;
     public static final int FROM_ID_START_ACTIVITY = 1002;
 }

--- a/projects/sample/source/sample-host/src/main/AndroidManifest.xml
+++ b/projects/sample/source/sample-host/src/main/AndroidManifest.xml
@@ -83,18 +83,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
         <provider
             android:authorities="com.tencent.shadow.contentprovider.authority.dynamic"
             android:name="com.tencent.shadow.core.runtime.container.PluginContainerContentProvider"
             android:grantUriPermissions="true"
             android:process=":plugin"
             />
-
         <service android:name="com.tencent.shadow.sample.host.PluginProcessPPS"
             android:process=":plugin"
             />
-
+        <service
+            android:name="com.tencent.shadow.sample.host.Plugin2ProcessPPS"
+            android:process=":plugin2" />
         <activity
             android:name="com.tencent.shadow.sample.host.PluginLoadActivity"
             android:launchMode="standard"
@@ -112,7 +112,7 @@
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|screenLayout|fontScale|uiMode|orientation|screenSize|smallestScreenSize|layoutDirection"
             android:hardwareAccelerated="true"
             android:theme="@style/troop_Transparent"
-            android:process=":plugin"
+            android:multiprocess="true"
             />
 
         <activity
@@ -122,7 +122,7 @@
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|screenLayout|fontScale|uiMode|orientation|screenSize|smallestScreenSize|layoutDirection"
             android:hardwareAccelerated="true"
             android:theme="@style/troop_Transparent"
-            android:process=":plugin"
+            android:multiprocess="true"
             />
 
         <activity
@@ -132,7 +132,8 @@
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|screenLayout|fontScale|uiMode|orientation|screenSize|smallestScreenSize|layoutDirection"
             android:hardwareAccelerated="true"
             android:theme="@style/troop_Transparent"
-            android:process=":plugin"
+            android:multiprocess="true"
+
             />
         <!--dynamic activity注册 end -->
     </application>

--- a/projects/sample/source/sample-host/src/main/java/com/tencent/shadow/sample/host/HostApplication.java
+++ b/projects/sample/source/sample-host/src/main/java/com/tencent/shadow/sample/host/HostApplication.java
@@ -23,6 +23,7 @@ import android.app.Application;
 import android.content.Context;
 import android.os.Build;
 import android.os.StrictMode;
+import android.webkit.WebView;
 
 import com.tencent.shadow.core.common.LoggerFactory;
 import com.tencent.shadow.dynamic.host.DynamicRuntime;
@@ -45,7 +46,7 @@ public class HostApplication extends Application {
         sApp = this;
 
         detectNonSdkApiUsageOnAndroidP();
-
+        setWebViewDataDirectorySuffix();
         LoggerFactory.setILoggerFactory(new AndroidLogLoggerFactory());
 
         if (isProcess(this, ":plugin")) {
@@ -59,7 +60,12 @@ public class HostApplication extends Application {
 
         HostUiLayerProvider.init(this);
     }
-
+    private static void setWebViewDataDirectorySuffix(){
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            return;
+        }
+        WebView.setDataDirectorySuffix(Application.getProcessName());
+    }
     private static void detectNonSdkApiUsageOnAndroidP() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
             return;

--- a/projects/sample/source/sample-host/src/main/java/com/tencent/shadow/sample/host/MainActivity.java
+++ b/projects/sample/source/sample-host/src/main/java/com/tencent/shadow/sample/host/MainActivity.java
@@ -51,7 +51,8 @@ public class MainActivity extends Activity {
         final Spinner partKeySpinner = new Spinner(this);
         ArrayAdapter<String> partKeysAdapter = new ArrayAdapter<>(this, R.layout.part_key_adapter);
         partKeysAdapter.addAll(
-                Constant.PART_KEY_PLUGIN_MAIN_APP
+                Constant.PART_KEY_PLUGIN_MAIN_APP,
+                Constant.PART_KEY_PLUGIN_ANOTHER_APP
         );
         partKeySpinner.setAdapter(partKeysAdapter);
 
@@ -66,9 +67,12 @@ public class MainActivity extends Activity {
                 Intent intent = new Intent(MainActivity.this, PluginLoadActivity.class);
                 intent.putExtra(Constant.KEY_PLUGIN_PART_KEY, partKey);
                 switch (partKey) {
+                    //为了演示多进程多插件，其实两个插件内容完全一样，除了所在进程
                     case Constant.PART_KEY_PLUGIN_MAIN_APP:
+                    case Constant.PART_KEY_PLUGIN_ANOTHER_APP:
                         intent.putExtra(Constant.KEY_ACTIVITY_CLASSNAME, "com.tencent.shadow.sample.plugin.app.lib.gallery.splash.SplashActivity");
                         break;
+
                 }
                 startActivity(intent);
             }

--- a/projects/sample/source/sample-host/src/main/java/com/tencent/shadow/sample/host/Plugin2ProcessPPS.java
+++ b/projects/sample/source/sample-host/src/main/java/com/tencent/shadow/sample/host/Plugin2ProcessPPS.java
@@ -1,0 +1,43 @@
+/*
+ * Tencent is pleased to support the open source community by making Tencent Shadow available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.tencent.shadow.sample.host;
+
+import android.content.pm.ApplicationInfo;
+import android.content.res.Resources;
+import android.util.Log;
+
+import com.tencent.shadow.dynamic.host.PluginProcessService;
+import com.tencent.shadow.sample.host.lib.LoadPluginCallback;
+
+public class Plugin2ProcessPPS extends PluginProcessService {
+    public Plugin2ProcessPPS() {
+        LoadPluginCallback.setCallback(new LoadPluginCallback.Callback() {
+
+            @Override
+            public void beforeLoadPlugin(String partKey) {
+                Log.d("Plugin2ProcessPPS", "beforeLoadPlugin(" + partKey + ")");
+            }
+
+            @Override
+            public void afterLoadPlugin(String partKey, ApplicationInfo applicationInfo, ClassLoader pluginClassLoader, Resources pluginResources) {
+                Log.d("Plugin2ProcessPPS", "afterLoadPlugin(" + partKey + "," + applicationInfo.className + "{metaData=" + applicationInfo.metaData + "}" + "," + pluginClassLoader + ")");
+            }
+        });
+    }
+}

--- a/projects/sample/source/sample-manager/src/main/java/com/tencent/shadow/sample/manager/FastPluginManager.java
+++ b/projects/sample/source/sample-manager/src/main/java/com/tencent/shadow/sample/manager/FastPluginManager.java
@@ -18,7 +18,6 @@
 
 package com.tencent.shadow.sample.manager;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.RemoteException;
@@ -113,12 +112,11 @@ public abstract class FastPluginManager extends PluginManagerThatUseDynamicLoade
     }
 
 
-    public void startPluginActivity(Context context, InstalledPlugin installedPlugin, String partKey, Intent pluginIntent) throws RemoteException, TimeoutException, FailedException {
+    public void startPluginActivity( InstalledPlugin installedPlugin, String partKey, Intent pluginIntent) throws RemoteException, TimeoutException, FailedException {
         Intent intent = convertActivityIntent(installedPlugin, partKey, pluginIntent);
-        if (!(context instanceof Activity)) {
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        }
-        context.startActivity(intent);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        mPluginLoader.startActivityInPluginProcess(intent);
+
     }
 
     public Intent convertActivityIntent(InstalledPlugin installedPlugin, String partKey, Intent pluginIntent) throws RemoteException, TimeoutException, FailedException {

--- a/projects/sample/source/sample-manager/src/main/java/com/tencent/shadow/sample/manager/SamplePluginManager.java
+++ b/projects/sample/source/sample-manager/src/main/java/com/tencent/shadow/sample/manager/SamplePluginManager.java
@@ -66,8 +66,8 @@ public class SamplePluginManager extends FastPluginManager {
     protected String getPluginProcessServiceName(String partKey) {
         if ("sample-plugin-app".equals(partKey)) {
             return "com.tencent.shadow.sample.host.PluginProcessPPS";
-        //} else if ("another-plugin-app".equals(partKey)) {
-        //    return "";//在这里支持多个插件
+        } else if ("sample-plugin-app2".equals(partKey)) {
+            return "com.tencent.shadow.sample.host.Plugin2ProcessPPS";//在这里支持多个插件
         } else {
             //如果有默认PPS，可用return代替throw
             throw new IllegalArgumentException("unexpected plugin load request: " + partKey);
@@ -113,7 +113,7 @@ public class SamplePluginManager extends FastPluginManager {
                         pluginIntent.replaceExtras(extras);
                     }
 
-                    startPluginActivity(context, installedPlugin, partKey, pluginIntent);
+                    startPluginActivity(installedPlugin, partKey, pluginIntent);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }

--- a/projects/sample/source/sample-plugin/sample-plugin-app/build.gradle
+++ b/projects/sample/source/sample-plugin/sample-plugin-app/build.gradle
@@ -48,6 +48,14 @@ shadow {
                         apkPath = 'projects/sample/source/sample-plugin/sample-plugin-app/build/outputs/apk/debug/sample-plugin-app-debug.apk'
                         hostWhiteList = ["com.tencent.shadow.sample.host.lib"]
                     }
+                    pluginApk2 {
+                        businessName = 'sample-plugin-app2'
+                        partKey = 'sample-plugin-app2'
+                        buildTask = ':sample-plugin-app:assembleDebug'
+                        apkName = 'sample-plugin-app-debug.apk'
+                        apkPath = 'projects/sample/source/sample-plugin/sample-plugin-app/build/outputs/apk/debug/sample-plugin-app-debug.apk'
+                        hostWhiteList = ["com.tencent.shadow.sample.host.lib"]
+                    }
                 }
             }
 
@@ -58,6 +66,14 @@ shadow {
                     pluginApk1 {
                         businessName = 'sample-plugin-app'
                         partKey = 'sample-plugin-app'
+                        buildTask = ':sample-plugin-app:assembleRelease'
+                        apkName = 'sample-plugin-app-release.apk'
+                        apkPath = 'projects/sample/source/sample-plugin/sample-plugin-app/build/outputs/apk/release/sample-plugin-app-release.apk'
+                        hostWhiteList = ["com.tencent.shadow.sample.host.lib"]
+                    }
+                    pluginApk2 {
+                        businessName = 'sample-plugin-app2'
+                        partKey = 'sample-plugin-app2'
                         buildTask = ':sample-plugin-app:assembleRelease'
                         apkName = 'sample-plugin-app-release.apk'
                         apkPath = 'projects/sample/source/sample-plugin/sample-plugin-app/build/outputs/apk/release/sample-plugin-app-release.apk'

--- a/projects/sdk/dynamic/dynamic-loader-impl/src/main/kotlin/com/tencent/shadow/dynamic/loader/impl/DynamicPluginLoader.kt
+++ b/projects/sdk/dynamic/dynamic-loader-impl/src/main/kotlin/com/tencent/shadow/dynamic/loader/impl/DynamicPluginLoader.kt
@@ -184,6 +184,13 @@ internal class DynamicPluginLoader(hostContext: Context, uuid: String) {
         }
     }
 
+    @Synchronized
+    fun startActivityInPluginProcess(intent: Intent) {
+        mUiHandler.post {
+            mContext.startActivity(intent)
+        }
+    }
+
     private class ServiceConnectionWrapper(private val mConnection: BinderPluginServiceConnection) : ServiceConnection {
 
         override fun onServiceDisconnected(name: ComponentName) {

--- a/projects/sdk/dynamic/dynamic-loader-impl/src/main/kotlin/com/tencent/shadow/dynamic/loader/impl/PluginLoaderBinder.kt
+++ b/projects/sdk/dynamic/dynamic-loader-impl/src/main/kotlin/com/tencent/shadow/dynamic/loader/impl/PluginLoaderBinder.kt
@@ -18,6 +18,7 @@
 
 package com.tencent.shadow.dynamic.loader.impl
 
+import android.content.Intent
 import android.os.IBinder
 import com.tencent.shadow.dynamic.host.PluginLoaderImpl
 import com.tencent.shadow.dynamic.host.UuidManager
@@ -126,6 +127,12 @@ internal class PluginLoaderBinder(private val mDynamicPluginLoader: DynamicPlugi
             PluginLoader.TRANSACTION_unbindService -> {
                 data.enforceInterface(PluginLoader.DESCRIPTOR)
                 mDynamicPluginLoader.unbindService(data.readStrongBinder())
+                reply!!.writeNoException()
+                return true
+            }
+            PluginLoader.TRANSACTION_startActivityInPluginProcess -> {
+                data.enforceInterface(PluginLoader.DESCRIPTOR)
+                mDynamicPluginLoader.startActivityInPluginProcess(Intent.CREATOR.createFromParcel(data))
                 reply!!.writeNoException()
                 return true
             }

--- a/projects/sdk/dynamic/dynamic-loader/src/main/java/com/tencent/shadow/dynamic/loader/PluginLoader.java
+++ b/projects/sdk/dynamic/dynamic-loader/src/main/java/com/tencent/shadow/dynamic/loader/PluginLoader.java
@@ -39,6 +39,8 @@ public interface PluginLoader {
     int TRANSACTION_stopPluginService = (IBinder.FIRST_CALL_TRANSACTION + 5);
     int TRANSACTION_bindPluginService = (IBinder.FIRST_CALL_TRANSACTION + 6);
     int TRANSACTION_unbindService = (IBinder.FIRST_CALL_TRANSACTION + 7);
+    int TRANSACTION_startActivityInPluginProcess = (IBinder.FIRST_CALL_TRANSACTION + 8);
+
 
     void loadPlugin(String partKey) throws RemoteException;
 
@@ -55,5 +57,7 @@ public interface PluginLoader {
     boolean bindPluginService(Intent pluginServiceIntent, PluginServiceConnection connection, int flags) throws RemoteException;
 
     void unbindService(PluginServiceConnection conn) throws RemoteException;
+
+    void startActivityInPluginProcess(Intent intent) throws RemoteException;
 
 }

--- a/projects/sdk/dynamic/dynamic-manager/src/main/java/com/tencent/shadow/dynamic/manager/BinderPluginLoader.java
+++ b/projects/sdk/dynamic/dynamic-manager/src/main/java/com/tencent/shadow/dynamic/manager/BinderPluginLoader.java
@@ -200,4 +200,19 @@ class BinderPluginLoader implements PluginLoader {
             _data.recycle();
         }
     }
+
+    @Override
+    public void startActivityInPluginProcess(Intent intent) throws RemoteException {
+        Parcel _data = Parcel.obtain();
+        Parcel _reply = Parcel.obtain();
+        try {
+            _data.writeInterfaceToken(DESCRIPTOR);
+            intent.writeToParcel(_data, 0);
+            mRemote.transact(TRANSACTION_startActivityInPluginProcess, _data, _reply, 0);
+            _reply.readException();
+        } finally {
+            _reply.recycle();
+            _data.recycle();
+        }
+    }
 }


### PR DESCRIPTION
未实现contentprovider的multiprocess。contentprovider如果设置了multiprocess首先多个进程会创建多个实例，在使用demo测试时能正常使用插件ContentProvider DB增删改查，但是使用FileProvider拍照之后会回调到主进程的ContentProvider.有点疑惑，貌似google让不要给它设置多进程[参考](https://issuetracker.google.com/issues/37113675)

不知道我这样实现有问题没，麻烦看一下