### PR TITLE
fix: 修正startActivityFromChild方法签名，明确不支持该接口

### DIFF
--- a/projects/sdk/coding/code-generator/src/main/kotlin/com/tencent/shadow/coding/code_generator/ActivityCodeGenerator.kt
+++ b/projects/sdk/coding/code-generator/src/main/kotlin/com/tencent/shadow/coding/code_generator/ActivityCodeGenerator.kt
@@ -6,14 +6,12 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.Application
 import android.app.FragmentManager
-import android.content.Intent
 import android.view.ContextThemeWrapper
 import android.view.KeyEvent
 import android.view.Window
 import com.squareup.javapoet.*
 import javassist.ClassMap
 import javassist.ClassPool
-import javassist.CtMethod
 import javassist.bytecode.Descriptor
 import java.io.File
 import java.lang.reflect.Method
@@ -106,16 +104,7 @@ class ActivityCodeGenerator {
                 newClassNames.add(newClassName)
             }
 
-            //因为之前的手工实现中有些方法没有实现，签名也就没有修改，所以暂时保持它们不变
-            //在rename前先remove掉它们，在rename后再添加回去
-            val keepMethods = mutableListOf<CtMethod>()
-
-            keepMethods.addAll(ctClass.getDeclaredMethods("startActivityFromChild").toList())
-
-            keepMethods.forEach { ctClass.removeMethod(it) }
             ctClass.replaceClassName(renameMap)
-            keepMethods.forEach { ctClass.addMethod(it) }
-
             return ctClass.toClass()
         }
 
@@ -148,7 +137,6 @@ class ActivityCodeGenerator {
 
             addMethod("isChangingConfigurations")
             addMethod("finish")
-            addMethod("startActivityFromChild", Activity::class.java, Intent::class.java, Int::class.javaPrimitiveType!!)
             addMethod("getClassLoader")
             addMethod("getLayoutInflater")
             addMethod("getResources")

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowActivity.java
@@ -183,4 +183,30 @@ public abstract class ShadowActivity extends PluginActivity {
     public ComponentName getCallingActivity() {
         return mCallingActivity;
     }
+
+    /**
+     * https://developer.android.com/reference/android/app/Activity#startActivityFromChild(android.app.Activity,%20android.content.Intent,%20int,%20android.os.Bundle)
+     * <p>
+     * This method was deprecated in API level R.
+     * Use androidx.fragment.app.FragmentActivity#startActivityFromFragment( androidx.fragment.app.Fragment,Intent,int,Bundle)
+     * <p>
+     * 不计划支持这个方法了。
+     */
+    @Override
+    public void startActivityFromChild(ShadowActivity arg0, Intent arg1, int arg2) {
+        throw new UnsupportedOperationException("Unsupported");
+    }
+
+    /**
+     * https://developer.android.com/reference/android/app/Activity#startActivityFromChild(android.app.Activity,%20android.content.Intent,%20int,%20android.os.Bundle)
+     * <p>
+     * This method was deprecated in API level R.
+     * Use androidx.fragment.app.FragmentActivity#startActivityFromFragment( androidx.fragment.app.Fragment,Intent,int,Bundle)
+     * <p>
+     * 不计划支持这个方法了。
+     */
+    @Override
+    public void startActivityFromChild(ShadowActivity arg0, Intent arg1, int arg2, Bundle arg3) {
+        throw new UnsupportedOperationException("Unsupported");
+    }
 }


### PR DESCRIPTION
由于startActivityFromChild方法不易支持，且已计划deprecated，又可以被androidx中的FragmentActivity替代。因此不投入精力实现该接口了。

#287