### PR TITLE
修复dev分支testSdk失败的两个错误

### DIFF
--- a/projects/sdk/core/manager/src/androidTest/java/com/tencent/shadow/core/manager/installplugin/CopySoBlocTest.java
+++ b/projects/sdk/core/manager/src/androidTest/java/com/tencent/shadow/core/manager/installplugin/CopySoBlocTest.java
@@ -48,6 +48,8 @@ public class CopySoBlocTest {
 
     @After
     public void tearDown() throws Exception {
+        if (!apkFile.exists()) return;
+
         FileUtils.deleteDirectory(soDir);
         copiedTagFile.delete();
     }

--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/OverrideCheck.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/OverrideCheck.kt
@@ -112,9 +112,14 @@ class OverrideCheck {
             val methodsDeclaredInClass = mutableListOf<Pair<CtMethod, String>>()
             declaredMethods.forEach {
                 try {
-                    val methodOfSuperClass = superclass.getMethod(it.name, it.genericSignature)
+                    val methodOfSuperClass = superclass.getMethod(it.name, it.signature)
                     methodsDeclaredInClass.add(it to methodOfSuperClass.declaringClass.name)
                 } catch (ignored: NotFoundException) {
+                    try {
+                        val methodOfSuperClass = superclass.getMethod(it.name, it.genericSignature)
+                        methodsDeclaredInClass.add(it to methodOfSuperClass.declaringClass.name)
+                    } catch (ignored: NotFoundException) {
+                    }
                 }
             }
             return methodsDeclaredInClass
@@ -122,8 +127,13 @@ class OverrideCheck {
 
         private fun CtClass.hasSameMethod(m: CtMethod) =
                 try {
-                    getMethod(m.name, m.genericSignature)
-                    true
+                    try {
+                        getMethod(m.name, m.signature)
+                        true
+                    } catch (ignored: NotFoundException) {
+                        getMethod(m.name, m.genericSignature)
+                        true
+                    }
                 } catch (ignored: NotFoundException) {
                     false
                 }


### PR DESCRIPTION
已修复dev分支上testSdk失败的两个错误。已在API19和API28两台虚拟机上执行testSdk任务。