### PR TITLE
改写 inPackage 方法及优化插件白名单测试用例

### DIFF
--- a/projects/sdk/core/loader/src/test/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoaderTest.kt
+++ b/projects/sdk/core/loader/src/test/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoaderTest.kt
@@ -218,6 +218,18 @@ class PluginClassLoaderTest {
         val className = "com.tencentshadow.next.MyClass"
         Assert.assertFalse(className.inPackage(packageNames))
     }
+
+    @Test
+    fun case75() {
+        //允许retrofit2包中的类和retrofit2包中所有子包中的类
+        val packageNames = arrayOf("retrofit2", "retrofit2.**")
+        val className1 = "retrofit2.Retrofit\$Builder"
+        val className2 = "retrofit2.a.Retrofit\$Builder"
+        val className3 = "retrofit2.a.b.Retrofit\$Builder"
+        Assert.assertTrue(className1.inPackage(packageNames))
+        Assert.assertTrue(className2.inPackage(packageNames))
+        Assert.assertTrue(className3.inPackage(packageNames))
+    }
 }
 
 


### PR DESCRIPTION
插件白名单书写规范

1. 不支持 `[空字符串]` `.` `.*` `.**`
2. 支持格式 `a.b.c.*` ：仅 `a.b.c` 包下的类
  - [x] a.b.c.E
  - [ ] a.b.c.d.E
  - [ ] a.b.E
3. 支持格式 `a.b.c.**` ：包括`a.b.c` 包及其子包的类
  - [x] a.b.c.E
  - [x] a.b.c.d.E
  - [ ] a.b.E
4. 支持格式 `a.b.c`  ：只写包名，等价于`a.b.c.*`
  - [x] a.b.c.E
  - [ ] a.b.c.d.E
  - [ ] a.b.E