### PR TITLE
test: 手工实验Window.setWindowAnimations

### DIFF
--- a/projects/sample/source/sample-plugin/sample-app-lib/src/main/AndroidManifest.xml
+++ b/projects/sample/source/sample-plugin/sample-app-lib/src/main/AndroidManifest.xml
@@ -76,6 +76,7 @@
         <activity android:name="com.tencent.shadow.sample.plugin.app.lib.usecases.context.ApplicationContextSubDirTestActivity" />
         <activity android:name=".usecases.host_communication.PluginUseHostClassActivity" />
         <activity android:name=".usecases.webview.WebViewActivity" />
+        <activity android:name=".usecases.fragment.TestDialogFragmentActivity" />
 
         <provider
             android:authorities="com.tencent.shadow.provider.test"

--- a/projects/sample/source/sample-plugin/sample-app-lib/src/main/java/com/tencent/shadow/sample/plugin/app/lib/gallery/cases/UseCaseManager.java
+++ b/projects/sample/source/sample-plugin/sample-app-lib/src/main/java/com/tencent/shadow/sample/plugin/app/lib/gallery/cases/UseCaseManager.java
@@ -31,6 +31,7 @@ import com.tencent.shadow.sample.plugin.app.lib.usecases.activity.TestAppCompatA
 import com.tencent.shadow.sample.plugin.app.lib.usecases.context.ActivityContextSubDirTestActivity;
 import com.tencent.shadow.sample.plugin.app.lib.usecases.context.ApplicationContextSubDirTestActivity;
 import com.tencent.shadow.sample.plugin.app.lib.usecases.dialog.TestDialogActivity;
+import com.tencent.shadow.sample.plugin.app.lib.usecases.fragment.TestDialogFragmentActivity;
 import com.tencent.shadow.sample.plugin.app.lib.usecases.fragment.TestDynamicFragmentActivity;
 import com.tencent.shadow.sample.plugin.app.lib.usecases.fragment.TestXmlFragmentActivity;
 import com.tencent.shadow.sample.plugin.app.lib.usecases.host_communication.PluginUseHostClassActivity;
@@ -87,7 +88,8 @@ public class UseCaseManager {
 
         UseCaseCategory fragmentCategory = new UseCaseCategory("fragment测试用例",new UseCase[]{
                 new TestDynamicFragmentActivity.Case(),
-                new TestXmlFragmentActivity.Case()
+                new TestXmlFragmentActivity.Case(),
+                new TestDialogFragmentActivity.Case()
         });
         useCases.add(fragmentCategory);
 

--- a/projects/sample/source/sample-plugin/sample-app-lib/src/main/java/com/tencent/shadow/sample/plugin/app/lib/usecases/fragment/TestDialogFragment.java
+++ b/projects/sample/source/sample-plugin/sample-app-lib/src/main/java/com/tencent/shadow/sample/plugin/app/lib/usecases/fragment/TestDialogFragment.java
@@ -1,0 +1,53 @@
+package com.tencent.shadow.sample.plugin.app.lib.usecases.fragment;
+
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.TextView;
+
+import com.tencent.shadow.sample.plugin.app.lib.R;
+
+public class TestDialogFragment extends DialogFragment {
+
+    public static TestDialogFragment newInstance(Bundle bundle) {
+        TestDialogFragment testFragment = new TestDialogFragment();
+        testFragment.setArguments(bundle);
+        return testFragment;
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        return super.onCreateDialog(savedInstanceState);
+    }
+
+    @Override
+    public void onDismiss(DialogInterface dialog) {
+        super.onDismiss(dialog);
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
+        Window window = getDialog().getWindow();
+//        window.setWindowAnimations(android.R.style.Animation_Toast);
+        window.setWindowAnimations(R.style.dialog_exit_fade_out);
+
+        View view = inflater.inflate(R.layout.layout_fragment_test, null, false);
+        TextView textView = view.findViewById(R.id.tv_msg);
+        Bundle bundle = getArguments();
+        if (bundle != null) {
+            String msg = bundle.getString("msg");
+            if (!TextUtils.isEmpty(msg)) {
+                textView.setText(msg);
+            }
+        }
+        return view;
+    }
+}

--- a/projects/sample/source/sample-plugin/sample-app-lib/src/main/java/com/tencent/shadow/sample/plugin/app/lib/usecases/fragment/TestDialogFragmentActivity.java
+++ b/projects/sample/source/sample-plugin/sample-app-lib/src/main/java/com/tencent/shadow/sample/plugin/app/lib/usecases/fragment/TestDialogFragmentActivity.java
@@ -1,0 +1,60 @@
+/*
+ * Tencent is pleased to support the open source community by making Tencent Shadow available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.tencent.shadow.sample.plugin.app.lib.usecases.fragment;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+
+import com.tencent.shadow.sample.plugin.app.lib.R;
+import com.tencent.shadow.sample.plugin.app.lib.gallery.BaseActivity;
+import com.tencent.shadow.sample.plugin.app.lib.gallery.cases.entity.UseCase;
+
+public class TestDialogFragmentActivity extends BaseActivity {
+
+    public static class Case extends UseCase {
+        @Override
+        public String getName() {
+            return "DialogFragment相关测试";
+        }
+
+        @Override
+        public String getSummary() {
+            return "测试DialogFragment使用setWindowAnimations";
+        }
+
+        @Override
+        public Class getPageClass() {
+            return TestDialogFragmentActivity.class;
+        }
+    }
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.layout_fragment_activity);
+
+        String msg = "这是TestDialogFragment";
+        Bundle bundle = new Bundle();
+        bundle.putString("msg", msg);
+        TestDialogFragment testFragment = TestDialogFragment.newInstance(bundle);
+        testFragment.show(getFragmentManager(), "TestDialogFragment");
+
+        getWindow().setWindowAnimations(R.style.dialog_exit_fade_out);
+    }
+}

--- a/projects/sample/source/sample-plugin/sample-app-lib/src/main/res/anim/dialog_exit_fade_out.xml
+++ b/projects/sample/source/sample-plugin/sample-app-lib/src/main/res/anim/dialog_exit_fade_out.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <scale
+        android:duration="50000"
+        android:fromXScale="100%"
+        android:fromYScale="100%"
+        android:toXScale="0%"
+        android:toYScale="0%" />
+</set>

--- a/projects/sample/source/sample-plugin/sample-app-lib/src/main/res/layout/layout_fragment_activity.xml
+++ b/projects/sample/source/sample-plugin/sample-app-lib/src/main/res/layout/layout_fragment_activity.xml
@@ -20,7 +20,7 @@
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/white"
+    android:background="@android:color/transparent"
     android:orientation="horizontal">
 
 

--- a/projects/sample/source/sample-plugin/sample-app-lib/src/main/res/values/styles.xml
+++ b/projects/sample/source/sample-plugin/sample-app-lib/src/main/res/values/styles.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name ="activity_exit_fade_out" parent ="android:Animation" mce_bogus="1">
+        <item name="android:activityCloseExitAnimation">@anim/dialog_exit_fade_out</item>
+    </style>
+
+    <style name ="dialog_exit_fade_out" parent ="android:Animation" mce_bogus="1">
+        <item name="android:windowExitAnimation">@anim/dialog_exit_fade_out</item>
+    </style>
+</resources>


### PR DESCRIPTION
首先确认setWindowAnimations在插件环境下确实不生效。跟DialogFragment不相关，是直接跟Window相关的。在Activity上的window测试也是不生效的。

基本上确定这个属性只支持从安装的宿主apk中读取资源。可以测试Activity的关闭动画，实验中的动画非常慢。可以看到，动画过程中杀死app进程也不影响动画播放。说明这个动画不是在app进程中绘制的。

而且setWindowAnimations的注释中有说只允许使用系统动画，看起来是早期版本的限制。

Tencent/Shadow#332