### PR TITLE
fix(core.loader): 插件intent中真实数据丢失

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
@@ -108,8 +108,10 @@ class ShadowActivityDelegate(private val mDI: DI) : GeneratedShadowActivityDeleg
                         or ActivityInfo.CONFIG_SMALLEST_SCREEN_SIZE//系统本身就会单独对待这个属性，不声明也不会重启Activity。
                         or 0x20000000 //见ActivityInfo.CONFIG_WINDOW_CONFIGURATION 系统处理属性
                         )
-        mRawIntentExtraBundle = pluginInitBundle.getBundle(CM_EXTRAS_BUNDLE_KEY)
-        mHostActivityDelegator.intent.replaceExtras(mRawIntentExtraBundle)
+        if (savedInstanceState == null) {
+            mRawIntentExtraBundle = pluginInitBundle.getBundle(CM_EXTRAS_BUNDLE_KEY)
+            mHostActivityDelegator.intent.replaceExtras(mRawIntentExtraBundle)
+        }
         mHostActivityDelegator.intent.setExtrasClassLoader(mPluginClassLoader)
 
         mHostActivityDelegator.setTheme(pluginActivityInfo.themeResource)

--- a/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/ActivityReCreateTest.java
+++ b/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/ActivityReCreateTest.java
@@ -1,0 +1,64 @@
+/*
+ * Tencent is pleased to support the open source community by making Tencent Shadow available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.tencent.shadow.test.cases.plugin_main;
+
+import android.content.Intent;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.action.ViewActions;
+import androidx.test.espresso.matcher.ViewMatchers;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class ActivityReCreateTest extends PluginMainAppTest {
+
+    @Override
+    protected Intent getLaunchIntent() {
+        Intent pluginIntent = new Intent();
+        String packageName = ApplicationProvider.getApplicationContext().getPackageName();
+        pluginIntent.setClassName(
+                packageName,
+                "com.tencent.shadow.test.plugin.general_cases.lib.usecases.activity.TestActivityReCreate"
+        );
+        pluginIntent.putExtra("reCreateMsg", "beforeReCreate");
+        return pluginIntent;
+    }
+
+    @Test
+    public void testOnCreate() {
+        matchTextWithViewTag("tv_msg", "reCreateMsg:beforeReCreate");
+    }
+
+    @Test
+    public void testReCreate() {
+        matchTextWithViewTag("tv_msg", "reCreateMsg:beforeReCreate");
+
+        Espresso.onView(ViewMatchers.withTagValue(Matchers.<Object>is("button"))).perform(ViewActions.click());
+
+        matchTextWithViewTag("tv_msg", "reCreateMsg:afterReCreate");
+    }
+}

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/activity/TestActivityReCreate.java
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/activity/TestActivityReCreate.java
@@ -35,13 +35,13 @@ public class TestActivityReCreate extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.layout_recreate);
         TextView textView = findViewById(R.id.tv_msg);
-        boolean isRecreate = getIntent().getBooleanExtra("reCreate", false);
-        textView.setText("isRecreate:"+isRecreate);
+        String reCreateMsg = getIntent().getStringExtra("reCreateMsg");
+        textView.setText("reCreateMsg:" + reCreateMsg);
         ToastUtil.showToast(this, "onCreate");
     }
 
     public void reCreate(View view) {
-        getIntent().putExtra("reCreate", true);
+        getIntent().putExtra("reCreateMsg", "afterReCreate");
         recreate();
     }
 

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/res/layout/layout_recreate.xml
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/res/layout/layout_recreate.xml
@@ -27,6 +27,7 @@
 
     <Button
         android:id="@+id/button"
+        android:tag="button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
@@ -38,6 +39,7 @@
 
     <TextView
         android:id="@+id/tv_msg"
+        android:tag="tv_msg"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="30dp"


### PR DESCRIPTION
修改ShadowActivityDelegate中mRawIntentExtraBundle的赋值逻辑。
    
    测试用例新增ActivityReCreateTest：
    1、测试pluginIntent正常传递参数
    2、测试reCreate之后intent参数