### PR TITLE
fix: ShadowActivity和ShadowApplication初始化时调用setTheme

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/blocs/CreateApplicationBloc.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/blocs/CreateApplicationBloc.kt
@@ -60,6 +60,7 @@ object CreateApplicationBloc {
 
             //和ShadowActivityDelegate.initPluginActivity一样，attachBaseContext放到最后
             shadowApplication.setHostApplicationContextAsBase(hostAppContext)
+            shadowApplication.setTheme(applicationInfo.theme)
             return shadowApplication
         } catch (e: Exception) {
             throw CreateApplicationException(e)

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
@@ -114,14 +114,13 @@ class ShadowActivityDelegate(private val mDI: DI) : GeneratedShadowActivityDeleg
         }
         mHostActivityDelegator.intent.setExtrasClassLoader(mPluginClassLoader)
 
-        mHostActivityDelegator.setTheme(pluginActivityInfo.themeResource)
         try {
             val pluginActivity = mAppComponentFactory.instantiateActivity(
                     mPluginClassLoader,
                     pluginActivityClassName,
                     mHostActivityDelegator.intent
             )
-            initPluginActivity(pluginActivity)
+            initPluginActivity(pluginActivity, pluginActivityInfo)
             super.pluginActivity = pluginActivity
 
             if (mLogger.isDebugEnabled) {
@@ -149,7 +148,7 @@ class ShadowActivityDelegate(private val mDI: DI) : GeneratedShadowActivityDeleg
         }
     }
 
-    private fun initPluginActivity(pluginActivity: PluginActivity) {
+    private fun initPluginActivity(pluginActivity: PluginActivity, pluginActivityInfo: PluginActivityInfo) {
         pluginActivity.setHostActivityDelegator(mHostActivityDelegator)
         pluginActivity.setPluginResources(mPluginResources)
         pluginActivity.setPluginClassLoader(mPluginClassLoader)
@@ -167,6 +166,7 @@ class ShadowActivityDelegate(private val mDI: DI) : GeneratedShadowActivityDeleg
         //有可能会执行业务Activity覆盖的逻辑。
         //所以，这个调用要放在最后。
         pluginActivity.setHostContextAsBase(mHostActivityDelegator.hostActivity as Context)
+        pluginActivity.setTheme(pluginActivityInfo.themeResource)
     }
 
     override fun getLoaderVersion() = BuildConfig.VERSION_NAME

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginActivity.java
@@ -91,4 +91,11 @@ public abstract class PluginActivity extends GeneratedPluginActivity {
     public void setCallingActivity(ComponentName callingActivity) {
         mCallingActivity = callingActivity;
     }
+
+    @Override
+    public void setTheme(int resid) {
+        super.setTheme(resid);
+        hostActivityDelegator.setTheme(resid);
+    }
+
 }

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowActivity.java
@@ -160,11 +160,6 @@ public abstract class ShadowActivity extends PluginActivity {
     }
 
     @Override
-    public void setTheme(int resid) {
-        hostActivityDelegator.setTheme(resid);
-    }
-
-    @Override
     public ComponentName getCallingActivity() {
         return mCallingActivity;
     }

--- a/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/ThemeTest.java
+++ b/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/ThemeTest.java
@@ -1,0 +1,56 @@
+/*
+ * Tencent is pleased to support the open source community by making Tencent Shadow available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.tencent.shadow.test.cases.plugin_main;
+
+import android.content.Intent;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class ThemeTest extends PluginMainAppTest {
+
+    @Override
+    protected Intent getLaunchIntent() {
+        Intent pluginIntent = new Intent();
+        String packageName = ApplicationProvider.getApplicationContext().getPackageName();
+        pluginIntent.setClassName(
+                packageName,
+                "com.tencent.shadow.test.plugin.general_cases.lib.usecases.context.TestThemeActivity"
+        );
+        return pluginIntent;
+    }
+
+    @Test
+    public void testApplicationTheme() {
+        matchTextWithViewTag("ApplicationThemeName", "android:style/Theme.NoTitleBar");
+    }
+
+    @Test
+    public void testActivityTheme() {
+        matchTextWithViewTag("ActivityThemeName", "android:style/Theme.NoTitleBar");
+    }
+
+}

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/AndroidManifest.xml
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/AndroidManifest.xml
@@ -70,6 +70,7 @@
         <activity android:name=".usecases.context.ActivityContextSubDirTestActivity" />
 
         <activity android:name=".usecases.context.ServiceContextSubDirTestActivity" />
+        <activity android:name=".usecases.context.TestThemeActivity" />
 
         <activity android:name=".usecases.context.ApplicationContextSubDirTestActivity" />
         <activity android:name=".usecases.application.TestGetApplicationInfoActivity" />

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/context/TestThemeActivity.java
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/context/TestThemeActivity.java
@@ -1,0 +1,71 @@
+/*
+ * Tencent is pleased to support the open source community by making Tencent Shadow available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.tencent.shadow.test.plugin.general_cases.lib.usecases.context;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.ContextThemeWrapper;
+import android.view.ViewGroup;
+
+import com.tencent.shadow.test.plugin.general_cases.lib.gallery.util.UiUtil;
+
+import java.lang.reflect.Method;
+
+public class TestThemeActivity extends Activity {
+
+    private ViewGroup mItemViewGroup;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mItemViewGroup = UiUtil.setActivityContentView(this);
+
+        mItemViewGroup.addView(
+                UiUtil.makeItem(
+                        this,
+                        "ApplicationThemeName",
+                        "ApplicationThemeName",
+                        getThemeName(getApplicationContext())
+                )
+        );
+
+        mItemViewGroup.addView(
+                UiUtil.makeItem(
+                        this,
+                        "ActivityThemeName",
+                        "ActivityThemeName",
+                        getThemeName(this)
+                )
+        );
+    }
+
+    private static String getThemeName(Context context) {
+        try {
+            Class<?> clazz = ContextThemeWrapper.class;
+            Method method = clazz.getMethod("getThemeResId");
+            method.setAccessible(true);
+            int themeResId = (Integer) method.invoke(context);
+            return context.getResources().getResourceName(themeResId);
+        } catch (Exception e) {
+            return "Exception: " + e.getMessage();
+        }
+    }
+}


### PR DESCRIPTION
否则在这两个对象上调用getTheme得到的是系统默认的Theme。

ShadowActivity同时保持调用壳子的setTheme，之前只设置了壳子的setTheme，没有设置自身的。

这个问题可能也是#214 的原因。

fix #384