### PR TITLE
在没有设置插件的主题前，一直返回空主题，否则执行到super.getTheme()将无法更换Resources

### DIFF
--- a/projects/sdk/core/activity-container/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerActivity.java
+++ b/projects/sdk/core/activity-container/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerActivity.java
@@ -41,6 +41,7 @@ public class PluginContainerActivity extends GeneratedPluginContainerActivity im
     HostActivityDelegate hostActivityDelegate;
 
     private boolean isBeforeOnCreate = true;
+    private boolean isThemeSet = false;
 
     public PluginContainerActivity() {
         HostActivityDelegate delegate;
@@ -157,7 +158,8 @@ public class PluginContainerActivity extends GeneratedPluginContainerActivity im
 
     @Override
     public Resources.Theme getTheme() {
-        if (isBeforeOnCreate) {
+        //在没有设置插件的主题前，一直返回空主题，否则执行到super.getTheme()将无法更换Resources，比如AppCompatActivity
+        if (isBeforeOnCreate || !isThemeSet) {
             if (mHostTheme == null) {
                 mHostTheme = super.getResources().newTheme();
             }
@@ -171,6 +173,7 @@ public class PluginContainerActivity extends GeneratedPluginContainerActivity im
     public void setTheme(int resid) {
         if (!isBeforeOnCreate) {
             super.setTheme(resid);
+            isThemeSet = true;
         }
     }
 


### PR DESCRIPTION
AppCompatActivity在执行onCreate时，会访问theme，确定是否是AppCompat类型的主题，此时调用getTheme方法会进入到super.getTheme，此方法里面会初始化一个默认的主题，N以上系统带actionbar，导致后续的setTheme方法无法更换Resources对象