### PR TITLE
feat(instrumentation): 部分支持Instrumentation.newApplication方法

### DIFF
--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowInstrumentation.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowInstrumentation.java
@@ -20,11 +20,24 @@ package com.tencent.shadow.core.runtime;
 
 import android.app.Activity;
 import android.app.Instrumentation;
+import android.content.Context;
 
 public class ShadowInstrumentation extends Instrumentation {
 
     public void callActivityOnDestroy(ShadowActivity activity) {
         Activity hostActivity = (Activity) activity.hostActivityDelegator.getHostActivity();
         super.callActivityOnDestroy(hostActivity);
+    }
+
+    static public ShadowApplication newShadowApplication(Class<?> clazz, Context context)
+            throws InstantiationException, IllegalAccessException,
+            ClassNotFoundException {
+        ShadowApplication app = (ShadowApplication) clazz.newInstance();
+
+        app.attachBaseContext(context);
+
+        //这样构造的 ShadowApplication 跟 CreateApplicationBloc 正常构造的不一样。
+        //这里构造的只是个Context而已，没有插件的各种信息。
+        return app;
     }
 }

--- a/projects/sdk/core/transform/src/test/java/com/tencent/shadow/core/runtime/ShadowApplication.java
+++ b/projects/sdk/core/transform/src/test/java/com/tencent/shadow/core/runtime/ShadowApplication.java
@@ -1,0 +1,4 @@
+package com.tencent.shadow.core.runtime;
+
+public class ShadowApplication {
+}

--- a/projects/sdk/core/transform/src/test/java/com/tencent/shadow/core/runtime/ShadowInstrumentation.java
+++ b/projects/sdk/core/transform/src/test/java/com/tencent/shadow/core/runtime/ShadowInstrumentation.java
@@ -1,0 +1,14 @@
+package com.tencent.shadow.core.runtime;
+
+import android.content.Context;
+
+public class ShadowInstrumentation {
+    public void callActivityOnDestroy(ShadowActivity activity) {
+    }
+
+    static public ShadowApplication newShadowApplication(Class<?> clazz, Context context)
+            throws InstantiationException, IllegalAccessException,
+            ClassNotFoundException {
+        return null;
+    }
+}

--- a/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/InstrumentationTest.java
+++ b/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/InstrumentationTest.java
@@ -1,0 +1,32 @@
+package com.tencent.shadow.test.cases.plugin_main;
+
+import android.content.Intent;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Test;
+
+public class InstrumentationTest extends PluginMainAppTest {
+
+    @Override
+    protected Intent getLaunchIntent() {
+        Intent pluginIntent = new Intent();
+        String packageName = ApplicationProvider.getApplicationContext().getPackageName();
+        pluginIntent.setClassName(
+                packageName,
+                "com.tencent.shadow.test.plugin.general_cases.lib.usecases.instrumentation.TestInstrumentationActivity"
+        );
+        return pluginIntent;
+    }
+
+    @Test
+    public void testStaticMethod() {
+        matchTextWithViewTag("newApplicationSuccess", Boolean.toString(true));
+    }
+
+    @Test
+    public void testSubClassMemberMethod() {
+        matchTextWithViewTag("callActivityOnDestroySuccess", Boolean.toString(true));
+    }
+
+}

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/AndroidManifest.xml
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/AndroidManifest.xml
@@ -79,6 +79,7 @@
         <activity android:name=".usecases.fragment.FragmentStartedActivity" />
         <activity android:name=".usecases.context.RegisterNullReceiverActivity" />
         <activity android:name=".usecases.dialog.TestAlertDialogActivity" />
+        <activity android:name=".usecases.instrumentation.TestInstrumentationActivity" />
 
         <provider
             android:authorities="com.tencent.shadow.provider.test"

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/instrumentation/MyInstrumentation.java
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/instrumentation/MyInstrumentation.java
@@ -1,0 +1,6 @@
+package com.tencent.shadow.test.plugin.general_cases.lib.usecases.instrumentation;
+
+import android.app.Instrumentation;
+
+public class MyInstrumentation extends Instrumentation {
+}

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/instrumentation/TestInstrumentationActivity.java
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/instrumentation/TestInstrumentationActivity.java
@@ -1,0 +1,77 @@
+/*
+ * Tencent is pleased to support the open source community by making Tencent Shadow available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.tencent.shadow.test.plugin.general_cases.lib.usecases.instrumentation;
+
+import android.app.Activity;
+import android.app.Application;
+import android.app.Instrumentation;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.ViewGroup;
+
+import com.tencent.shadow.test.plugin.general_cases.lib.gallery.util.UiUtil;
+
+public class TestInstrumentationActivity extends Activity {
+
+    private ViewGroup mItemViewGroup;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mItemViewGroup = UiUtil.setActivityContentView(this);
+
+        boolean newApplicationSuccess = false;
+        try {
+            Application app = Instrumentation.newApplication(Application.class, getApplicationContext());
+            newApplicationSuccess = true;
+        } catch (Exception ignored) {
+        }
+
+        mItemViewGroup.addView(
+                UiUtil.makeItem(
+                        this,
+                        "newApplicationSuccess",
+                        "newApplicationSuccess",
+                        Boolean.toString(newApplicationSuccess)
+                )
+        );
+
+        boolean callActivityOnDestroySuccess = false;
+        try {
+            MyInstrumentation myInstrumentation = new MyInstrumentation();
+            TestInstrumentationActivity testActivity = new TestInstrumentationActivity();
+            myInstrumentation.callActivityOnDestroy(testActivity);
+        } catch (NullPointerException e) {
+            if (e.getMessage().contains("getHostActivity")) {
+                callActivityOnDestroySuccess = true;
+            }
+        }
+
+
+        mItemViewGroup.addView(
+                UiUtil.makeItem(
+                        this,
+                        "callActivityOnDestroySuccess",
+                        "callActivityOnDestroySuccess",
+                        Boolean.toString(callActivityOnDestroySuccess)
+                )
+        );
+    }
+
+}


### PR DESCRIPTION
目前的实现只是new出来插件中的ShadowApplication对象，设置其Base Context。
这个对象跟正常通过CreateApplicationBloc构造的插件Application区别很大，
不具有插件的各种信息。

此实现只能使依赖此方法的插件可以正常编译通过。如果插件中将此对象用于超出一般
Context之外的场景，则依然不能正常工作。

完整支持Instrumentation类需要非常大的工作量，需要在插件构造时就介入其中。

fix #397