### PR TITLE
feat(instrumentation): 部分支持Instrumentation方法

### DIFF
--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowInstrumentation.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowInstrumentation.java
@@ -19,8 +19,13 @@
 package com.tencent.shadow.core.runtime;
 
 import android.app.Activity;
+import android.app.Fragment;
 import android.app.Instrumentation;
 import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.os.PersistableBundle;
 
 public class ShadowInstrumentation extends Instrumentation {
 
@@ -40,4 +45,65 @@ public class ShadowInstrumentation extends Instrumentation {
         //这里构造的只是个Context而已，没有插件的各种信息。
         return app;
     }
+
+
+    /**
+     * 因为参数签名和newActivity一样,但是返回值不一样,所以无法override
+     * 只能通过transform,让newApplication转移到newShadowApplication上来
+     */
+    public ShadowApplication newShadowApplication(ClassLoader cl, String className, Context context)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        ShadowApplication app = (ShadowApplication) cl.loadClass(className).newInstance();
+        app.attachBaseContext(context);
+        return app;
+    }
+
+    /**
+     * 因为参数签名和newActivity一样,但是返回值不一样,所以无法override
+     * 只能通过transform,让newActivity转移到newShadowActivity上来
+     */
+    public ShadowActivity newShadowActivity(ClassLoader cl, String className, Intent intent)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        return (ShadowActivity) cl.loadClass(className).newInstance();
+    }
+
+    public void callApplicationOnCreate(ShadowApplication app) {
+        app.onCreate();
+    }
+
+    /**
+     * shadow启动插件activity时并不是依靠Instrumentation来操作的,所以这边的execStartActivity并没有什么实在的意义
+     * 而且这个方法里面都大量的UnsupportedAppUsage方法调用,如果重写并不符合shadow零反射的原则
+     * 所以,重写这个方法,但是仅仅返回一个空的ActivityResult只是是作为帮助编译通过的方法
+     * <p>
+     * 像com.didi.virtualapk是用自定义的Instrumentation做了一层代理,替换intent中合适的activity
+     * 但是shadow的activity不是这样启动的,这个方法也不会执行,仅仅保证编译通过,能正常打出插件包,而virtualapk其实是完全失效的
+     */
+    public ActivityResult execStartActivity(Context who, IBinder contextThread, IBinder token, ShadowActivity target, Intent intent, int requestCode) {
+        return new ActivityResult(requestCode, intent);
+    }
+
+    public ActivityResult execStartActivity(Context who, IBinder contextThread, IBinder token, ShadowActivity target, Intent intent, int requestCode, Bundle options) {
+        return new ActivityResult(requestCode, intent);
+    }
+
+    public ActivityResult execStartActivity(Context who, IBinder contextThread, IBinder token, Fragment target, Intent intent, int requestCode, Bundle options) {
+        return new ActivityResult(requestCode, intent);
+    }
+
+    public ActivityResult execStartActivity(Context who, IBinder contextThread, IBinder token, String target, Intent intent, int requestCode, Bundle options) {
+        return new ActivityResult(requestCode, intent);
+    }
+
+    /**
+     * 同execStartActivity方法一样,其实插件中并不会调用到这里
+     * 而且这个方法里面都大量的UnsupportedAppUsage方法调用,如果重写并不符合shadow零反射的原则
+     */
+    public void callActivityOnCreate(ShadowActivity activity, Bundle icicle) {
+    }
+
+    public void callActivityOnCreate(ShadowActivity activity, Bundle icicle, PersistableBundle persistentState) {
+    }
+
+
 }

--- a/projects/sdk/core/transform/src/test/java/android/app/Instrumentation.java
+++ b/projects/sdk/core/transform/src/test/java/android/app/Instrumentation.java
@@ -18,5 +18,11 @@
 
 package android.app;
 
+import android.content.Intent;
+
 public class Instrumentation {
+
+    public static class ActivityResult{
+        public ActivityResult(int code, Intent intent){}
+    }
 }

--- a/projects/sdk/core/transform/src/test/java/android/os/IBinder.java
+++ b/projects/sdk/core/transform/src/test/java/android/os/IBinder.java
@@ -1,0 +1,4 @@
+package android.os;
+
+public interface IBinder {
+}

--- a/projects/sdk/core/transform/src/test/java/com/tencent/shadow/core/runtime/ShadowApplication.java
+++ b/projects/sdk/core/transform/src/test/java/com/tencent/shadow/core/runtime/ShadowApplication.java
@@ -1,4 +1,7 @@
 package com.tencent.shadow.core.runtime;
 
 public class ShadowApplication {
+
+    public void onCreate() {
+    }
 }

--- a/projects/sdk/core/transform/src/test/java/com/tencent/shadow/core/runtime/ShadowInstrumentation.java
+++ b/projects/sdk/core/transform/src/test/java/com/tencent/shadow/core/runtime/ShadowInstrumentation.java
@@ -1,6 +1,11 @@
 package com.tencent.shadow.core.runtime;
 
+import android.app.Fragment;
+import android.app.Instrumentation;
 import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.IBinder;
 
 public class ShadowInstrumentation {
     public void callActivityOnDestroy(ShadowActivity activity) {
@@ -10,5 +15,35 @@ public class ShadowInstrumentation {
             throws InstantiationException, IllegalAccessException,
             ClassNotFoundException {
         return null;
+    }
+
+    public ShadowApplication newApplication(ClassLoader cl, String className, Context context)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        return null;
+    }
+
+    public ShadowActivity newShadowActivity(ClassLoader cl, String className, Intent intent)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        return (ShadowActivity) cl.loadClass(className).newInstance();
+    }
+
+    public void callApplicationOnCreate(ShadowApplication app) {
+        app.onCreate();
+    }
+
+    public Instrumentation.ActivityResult execStartActivity(Context who, IBinder contextThread, IBinder token, ShadowActivity target, Intent intent, int requestCode) {
+        return new Instrumentation.ActivityResult(requestCode, intent);
+    }
+
+    public Instrumentation.ActivityResult execStartActivity(Context who, IBinder contextThread, IBinder token, ShadowActivity target, Intent intent, int requestCode, Bundle options) {
+        return new Instrumentation.ActivityResult(requestCode, intent);
+    }
+
+    public Instrumentation.ActivityResult execStartActivity(Context who, IBinder contextThread, IBinder token, Fragment target, Intent intent, int requestCode, Bundle options) {
+        return new Instrumentation.ActivityResult(requestCode, intent);
+    }
+
+    public Instrumentation.ActivityResult execStartActivity(Context who, IBinder contextThread, IBinder token, String target, Intent intent, int requestCode, Bundle options) {
+        return new Instrumentation.ActivityResult(requestCode, intent);
     }
 }

--- a/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/InstrumentationTest.java
+++ b/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/InstrumentationTest.java
@@ -29,4 +29,34 @@ public class InstrumentationTest extends PluginMainAppTest {
         matchTextWithViewTag("callActivityOnDestroySuccess", Boolean.toString(true));
     }
 
+    @Test
+    public void testNewApplicationSuccess1() {
+        matchTextWithViewTag("newApplicationSuccess1", Boolean.toString(true));
+    }
+
+    @Test
+    public void testNewShadowActivitySuccess() {
+        matchTextWithViewTag("newShadowActivitySuccess", Boolean.toString(true));
+    }
+
+    @Test
+    public void testCallApplicationOnCreateSuccess() {
+        matchTextWithViewTag("callApplicationOnCreateSuccess", Boolean.toString(true));
+    }
+
+    @Test
+    public void testCallActivityOnCreateSuccess() {
+        matchTextWithViewTag("callActivityOnCreateSuccess", Boolean.toString(true));
+    }
+
+    @Test
+    public void testCallActivityOnCreateSuccess1() {
+        matchTextWithViewTag("callActivityOnCreateSuccess1", Boolean.toString(true));
+    }
+
+    @Test
+    public void testExecStartActivitySuccess() {
+        matchTextWithViewTag("execStartActivitySuccess", Boolean.toString(true));
+    }
+
 }

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/instrumentation/TestInstrumentationActivity.java
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/instrumentation/TestInstrumentationActivity.java
@@ -21,7 +21,9 @@ package com.tencent.shadow.test.plugin.general_cases.lib.usecases.instrumentatio
 import android.app.Activity;
 import android.app.Application;
 import android.app.Instrumentation;
+import android.os.Build;
 import android.os.Bundle;
+import android.os.PersistableBundle;
 import android.support.annotation.Nullable;
 import android.view.ViewGroup;
 
@@ -70,6 +72,119 @@ public class TestInstrumentationActivity extends Activity {
                         "callActivityOnDestroySuccess",
                         "callActivityOnDestroySuccess",
                         Boolean.toString(callActivityOnDestroySuccess)
+                )
+        );
+
+
+        boolean newApplicationSuccess1 = false;
+        try {
+            MyInstrumentation myInstrumentation = new MyInstrumentation();
+            Application app = myInstrumentation.newApplication(myInstrumentation.getClass().getClassLoader(),
+                    Application.class.getName(),
+                    getApplicationContext());
+            newApplicationSuccess1 = true;
+        } catch (Exception ignore) {
+        }
+
+
+        mItemViewGroup.addView(
+                UiUtil.makeItem(this,
+                        "newApplicationSuccess1",
+                        "newApplicationSuccess1",
+                        Boolean.toString(newApplicationSuccess1))
+        );
+
+
+        boolean newShadowActivitySuccess = false;
+        try {
+            MyInstrumentation myInstrumentation = new MyInstrumentation();
+            myInstrumentation.newActivity(myInstrumentation.getClass().getClassLoader(),
+                    TestInstrumentationActivity.class.getName(),
+                    null);
+            newShadowActivitySuccess = true;
+        } catch (Exception ignore) {
+        }
+
+
+        mItemViewGroup.addView(
+                UiUtil.makeItem(this,
+                        "newShadowActivitySuccess",
+                        "newShadowActivitySuccess",
+                        Boolean.toString(newShadowActivitySuccess))
+        );
+
+        boolean callApplicationOnCreateSuccess = false;
+        try {
+            MyInstrumentation myInstrumentation = new MyInstrumentation();
+            myInstrumentation.callApplicationOnCreate(getApplication());
+            callApplicationOnCreateSuccess = true;
+        } catch (Exception ignore) {
+        }
+
+
+        mItemViewGroup.addView(
+                UiUtil.makeItem(
+                        this,
+                        "callApplicationOnCreateSuccess",
+                        "callApplicationOnCreateSuccess",
+                        Boolean.toString(callApplicationOnCreateSuccess)
+                )
+        );
+
+        boolean callActivityOnCreateSuccess = false;
+        try {
+            MyInstrumentation myInstrumentation = new MyInstrumentation();
+            myInstrumentation.callActivityOnCreate(this, new Bundle());
+            callActivityOnCreateSuccess = true;
+        } catch (Exception ignore) {
+        }
+
+
+        mItemViewGroup.addView(
+                UiUtil.makeItem(
+                        this,
+                        "callActivityOnCreateSuccess",
+                        "callActivityOnCreateSuccess",
+                        Boolean.toString(callActivityOnCreateSuccess)
+                )
+        );
+
+        boolean callActivityOnCreateSuccess1 = false;
+        try {
+            MyInstrumentation myInstrumentation = new MyInstrumentation();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                myInstrumentation.callActivityOnCreate(this, new Bundle(), new PersistableBundle());
+            }
+            callActivityOnCreateSuccess1 = true;
+        } catch (Exception ignore) {
+        }
+
+
+        mItemViewGroup.addView(
+                UiUtil.makeItem(
+                        this,
+                        "callActivityOnCreateSuccess1",
+                        "callActivityOnCreateSuccess1",
+                        Boolean.toString(callActivityOnCreateSuccess1)
+                )
+        );
+
+        boolean execStartActivitySuccess = false;
+        try {
+            MyInstrumentation myInstrumentation = new MyInstrumentation();
+            // 这里是UnsupportedAppUsage的,无法测试
+//            myInstrumentation.execStartActivity(this, new Bundle(), new PersistableBundle());
+            execStartActivitySuccess = true;
+        } catch (Exception ignore) {
+        }
+
+
+        mItemViewGroup.addView(
+                UiUtil.makeItem(
+                        this,
+                        "execStartActivitySuccess",
+                        "execStartActivitySuccess",
+                        Boolean.toString(execStartActivitySuccess)
                 )
         );
     }


### PR DESCRIPTION
针对有些第三方arr依赖virtualApk的情况导致打插件包失败的情况,添加了部分导致失败的方法到Instrumentation中

因为VirtualApk依赖Instrumentation的子类进行代理,但是Shadow的插件运行不依赖Instrumentation,所以VirtualApk在插件中无效,仅仅是为了能够正常打出插件包来

和#397有一定关联

fix #397