### PR TITLE
feat(transform): 去掉检查App类是否可重编译的逻辑

### DIFF
--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/SpecificTransform.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/SpecificTransform.kt
@@ -43,21 +43,13 @@ abstract class SpecificTransform {
         methodInfo.descriptor = other.methodInfo.descriptor
     }
 
-    fun allCanRecompileAppClass(allAppClass: Set<CtClass>, targetClassList: List<String>) =
+    /**
+     * 过滤引用了某些类型的类
+     */
+    fun filterRefClasses(allAppClass: Set<CtClass>, targetClassList: List<String>) =
             allAppClass.filter { ctClass ->
                 targetClassList.any { targetClass ->
                     ctClass.refClasses.contains(targetClass)
-                }
-            }.filter {
-                it.refClasses.all {
-                    var found: Boolean;
-                    try {
-                        mClassPool[it as String]
-                        found = true
-                    } catch (e: NotFoundException) {
-                        found = false
-                    }
-                    found
                 }
             }.toSet()
 

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/ContentProviderTransform.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/ContentProviderTransform.kt
@@ -106,7 +106,7 @@ class ContentProviderTransform : SpecificTransform() {
 
         newStep(object : TransformStep {
             override fun filter(allInputClass: Set<CtClass>) =
-                    allCanRecompileAppClass(allInputClass, listOf(AndroidUriClassname))
+                    filterRefClasses(allInputClass, listOf(AndroidUriClassname))
 
             override fun transform(ctClass: CtClass) {
                 try {
@@ -120,7 +120,7 @@ class ContentProviderTransform : SpecificTransform() {
 
         newStep(object : TransformStep {
             override fun filter(allInputClass: Set<CtClass>) =
-                    allCanRecompileAppClass(allInputClass, listOf(uriBuilderName))
+                    filterRefClasses(allInputClass, listOf(uriBuilderName))
 
             override fun transform(ctClass: CtClass) {
                 try {
@@ -134,7 +134,7 @@ class ContentProviderTransform : SpecificTransform() {
 
         newStep(object : TransformStep {
             override fun filter(allInputClass: Set<CtClass>) =
-                    allCanRecompileAppClass(allInputClass, listOf(resolverName))
+                    filterRefClasses(allInputClass, listOf(resolverName))
 
             override fun transform(ctClass: CtClass) {
                 try {

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/KeepHostContextTransform.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/KeepHostContextTransform.kt
@@ -107,7 +107,7 @@ class KeepHostContextTransform(private val rules: Array<String>) : SpecificTrans
 
             newStep(object : TransformStep {
                 override fun filter(allInputClass: Set<CtClass>) =
-                        allCanRecompileAppClass(allInputClass, listOf(targetClass.name))
+                        filterRefClasses(allInputClass, listOf(targetClass.name))
 
                 override fun transform(ctClass: CtClass) {
                     if (ctClass != targetClass)

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/PackageItemInfoTransform.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/PackageItemInfoTransform.kt
@@ -46,7 +46,7 @@ class PackageItemInfoTransform : SpecificTransform() {
         targetMethods.forEach { targetMethod ->
             newStep(object : TransformStep {
                 override fun filter(allInputClass: Set<CtClass>) =
-                        allCanRecompileAppClass(
+                        filterRefClasses(
                                 allInputClass,
                                 targetClassNames.asList()
                         ).filter { matchMethodCallInClass(targetMethod, it) }.toSet()

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/PackageManagerTransform.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/PackageManagerTransform.kt
@@ -38,7 +38,7 @@ class PackageManagerTransform : SpecificTransform() {
         targetMethods.forEach { targetMethod ->
             newStep(object : TransformStep {
                 override fun filter(allInputClass: Set<CtClass>) =
-                        allCanRecompileAppClass(
+                        filterRefClasses(
                                 allInputClass,
                                 listOf(AndroidPackageManagerClassname)
                         ).filter { matchMethodCallInClass(targetMethod, it) }.toSet()

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/PendingIntentTransform.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/PendingIntentTransform.kt
@@ -49,7 +49,7 @@ class PendingIntentTransform : SpecificTransform() {
 
         newStep(object : TransformStep {
             override fun filter(allInputClass: Set<CtClass>) =
-                    allCanRecompileAppClass(allInputClass, listOf(AndroidPendingIntentClassname))
+                    filterRefClasses(allInputClass, listOf(AndroidPendingIntentClassname))
 
             override fun transform(ctClass: CtClass) {
                 try {

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/WebViewTransform.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/WebViewTransform.kt
@@ -35,7 +35,7 @@ class WebViewTransform : SpecificTransform() {
 
         newStep(object : TransformStep {
             override fun filter(allInputClass: Set<CtClass>) =
-                    allCanRecompileAppClass(allInputClass, listOf(AndroidWebViewClassname))
+                    filterRefClasses(allInputClass, listOf(AndroidWebViewClassname))
 
             override fun transform(ctClass: CtClass) {
                 if (ctClass.superclass.name == AndroidWebViewClassname) {
@@ -46,7 +46,7 @@ class WebViewTransform : SpecificTransform() {
 
         newStep(object : TransformStep {
             override fun filter(allInputClass: Set<CtClass>) =
-                    allCanRecompileAppClass(allInputClass, listOf(AndroidWebViewClassname))
+                    filterRefClasses(allInputClass, listOf(AndroidWebViewClassname))
 
             override fun transform(ctClass: CtClass) {
                 try {


### PR DESCRIPTION
因为支持了rebuildStackMap自动创建不存在的类之后就没必要再跳过Transform那些引用了不存在的类的类了。

所以现在Transform处理一些第三方库时，如果第三方库引用了找不到的类型，也可以正确处理其中Shadow需要Transform的地方了。