### PR TITLE
基本依赖工具版本维护

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@
 //请更新buildscript时同步更新。
 buildscript {
     ext.kotlin_version = '1.3.72'
-    ext.build_gradle_version = '3.6.3'
+    ext.build_gradle_version = '4.0.2'
     repositories {
         google()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 //buildscript不能从其他gradle文件中apply，所以这段buildscript脚本存在于多个子构建中。
 //请更新buildscript时同步更新。
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.4.10'
     ext.build_gradle_version = '4.0.2'
     repositories {
         google()

--- a/buildScripts/gradle/common.gradle
+++ b/buildScripts/gradle/common.gradle
@@ -8,7 +8,7 @@ def gitShortRev() {
 }
 
 allprojects {
-    ext.COMPILE_SDK_VERSION = 29
+    ext.COMPILE_SDK_VERSION = 30
     ext.MIN_SDK_VERSION = 14
     ext.TARGET_SDK_VERSION = 28
     ext.VERSION_CODE = 1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/projects/sample/maven/host-project/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/sample/maven/host-project/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip

--- a/projects/sample/maven/manager-project/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/sample/maven/manager-project/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip

--- a/projects/sample/maven/plugin-project/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/sample/maven/plugin-project/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip

--- a/projects/sample/sunflower/host-project/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/sample/sunflower/host-project/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip

--- a/projects/sample/sunflower/manager-project/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/sample/sunflower/manager-project/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip

--- a/projects/sample/sunflower/plugin-project/build.gradle
+++ b/projects/sample/sunflower/plugin-project/build.gradle
@@ -46,7 +46,7 @@ buildscript {
         truthVersion = '0.42'
         testExtJunit = '1.1.0'
         uiAutomatorVersion = '2.2.0'
-        viewPagerVersion = '1.0.0-rc01'
+        viewPagerVersion = '1.0.0'
         workVersion = '2.1.0'
     }
 

--- a/projects/sdk/coding/build.gradle
+++ b/projects/sdk/coding/build.gradle
@@ -4,7 +4,7 @@
 //请更新buildscript时同步更新。
 buildscript {
     ext.kotlin_version = '1.3.72'
-    ext.build_gradle_version = '3.6.3'
+    ext.build_gradle_version = '4.0.2'
     repositories {
         google()
         jcenter()

--- a/projects/sdk/coding/build.gradle
+++ b/projects/sdk/coding/build.gradle
@@ -3,7 +3,7 @@
 //buildscript不能从其他gradle文件中apply，所以这段buildscript脚本存在于多个子构建中。
 //请更新buildscript时同步更新。
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.4.10'
     ext.build_gradle_version = '4.0.2'
     repositories {
         google()

--- a/projects/sdk/coding/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/sdk/coding/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/projects/sdk/core/build.gradle
+++ b/projects/sdk/core/build.gradle
@@ -4,7 +4,7 @@
 //请更新buildscript时同步更新。
 buildscript {
     ext.kotlin_version = '1.3.72'
-    ext.build_gradle_version = '3.6.3'
+    ext.build_gradle_version = '4.0.2'
     repositories {
         google()
         jcenter()

--- a/projects/sdk/core/build.gradle
+++ b/projects/sdk/core/build.gradle
@@ -3,7 +3,7 @@
 //buildscript不能从其他gradle文件中apply，所以这段buildscript脚本存在于多个子构建中。
 //请更新buildscript时同步更新。
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.4.10'
     ext.build_gradle_version = '4.0.2'
     repositories {
         google()

--- a/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/build.gradle
+++ b/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.build_gradle_version = '3.6.3'
+    ext.build_gradle_version = '4.0.2'
     repositories {
         google()
         jcenter()

--- a/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/plugin1/build.gradle
+++ b/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/plugin1/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.build_gradle_version = '3.6.3'
+    ext.build_gradle_version = '4.0.2'
     repositories {
         google()
         jcenter()

--- a/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/plugin2/build.gradle
+++ b/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/plugin2/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.build_gradle_version = '3.6.3'
+    ext.build_gradle_version = '4.0.2'
     repositories {
         google()
         jcenter()

--- a/projects/sdk/core/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/sdk/core/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/managers/PluginPackageManagerImpl.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/managers/PluginPackageManagerImpl.kt
@@ -26,14 +26,14 @@ internal class PluginPackageManagerImpl(private val hostPackageManager: PackageM
                                         private val packageInfo: PackageInfo,
                                         private val allPluginPackageInfo: () -> (Array<PackageInfo>))
     : PluginPackageManager {
-    override fun getApplicationInfo(packageName: String?, flags: Int): ApplicationInfo =
+    override fun getApplicationInfo(packageName: String, flags: Int): ApplicationInfo =
             if (packageInfo.applicationInfo.packageName == packageName) {
                 packageInfo.applicationInfo
             } else {
                 hostPackageManager.getApplicationInfo(packageName, flags)
             }
 
-    override fun getPackageInfo(packageName: String?, flags: Int): PackageInfo? =
+    override fun getPackageInfo(packageName: String, flags: Int): PackageInfo? =
             if (packageInfo.applicationInfo.packageName == packageName) {
                 packageInfo
             } else {
@@ -54,7 +54,7 @@ internal class PluginPackageManagerImpl(private val hostPackageManager: PackageM
         return hostPackageManager.getActivityInfo(component, flags)
     }
 
-    override fun resolveContentProvider(name: String?, flags: Int): ProviderInfo? {
+    override fun resolveContentProvider(name: String, flags: Int): ProviderInfo? {
         val pluginProviderInfo = allPluginPackageInfo()
                 .flatMap { it.providers.asIterable() }.find {
                     it.authority == name

--- a/projects/sdk/core/manager/build.gradle
+++ b/projects/sdk/core/manager/build.gradle
@@ -25,12 +25,12 @@ android {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:core:1.3.0-rc01'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2-rc01'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0-rc01'
-    androidTestImplementation 'androidx.test.espresso:espresso-remote:3.3.0-rc01'
-    implementation 'androidx.test.espresso:espresso-idling-resource:3.3.0-rc01'
-    androidTestImplementation "androidx.test:runner:1.3.0-rc01"
+    androidTestImplementation 'androidx.test:core:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-remote:3.3.0'
+    implementation 'androidx.test.espresso:espresso-idling-resource:3.3.0'
+    androidTestImplementation "androidx.test:runner:1.3.0"
 
     androidTestImplementation 'commons-io:commons-io:2.5'
     androidTestImplementation project(':common')

--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransform.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransform.kt
@@ -81,6 +81,12 @@ abstract class AbstractTransform(
     }
 
     private fun CtClass.debugWriteJar(outputStream: ZipOutputStream) {
+        //忽略Kotlin 1.4引入的module-info
+        //https://kotlinlang.org/docs/reference/whatsnew14.html#module-info-descriptors-for-stdlib-artifacts
+        if (name == "module-info") {
+            return
+        }
+
         try {
             val entryName = (name.replace('.', '/') + ".class")
             outputStream.putNextEntry(ZipEntry(entryName))

--- a/projects/sdk/dynamic/build.gradle
+++ b/projects/sdk/dynamic/build.gradle
@@ -4,7 +4,7 @@
 //请更新buildscript时同步更新。
 buildscript {
     ext.kotlin_version = '1.3.72'
-    ext.build_gradle_version = '3.6.3'
+    ext.build_gradle_version = '4.0.2'
     repositories {
         google()
         jcenter()

--- a/projects/sdk/dynamic/build.gradle
+++ b/projects/sdk/dynamic/build.gradle
@@ -3,7 +3,7 @@
 //buildscript不能从其他gradle文件中apply，所以这段buildscript脚本存在于多个子构建中。
 //请更新buildscript时同步更新。
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.4.10'
     ext.build_gradle_version = '4.0.2'
     repositories {
         google()

--- a/projects/sdk/dynamic/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/sdk/dynamic/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/projects/test/dynamic/host/test-dynamic-host/build.gradle
+++ b/projects/test/dynamic/host/test-dynamic-host/build.gradle
@@ -49,12 +49,12 @@ dependencies {
     implementation project(':constant')
 
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:core:1.3.0-rc01'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2-rc01'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0-rc01'
-    androidTestImplementation 'androidx.test.espresso:espresso-remote:3.3.0-rc01'
-    implementation 'androidx.test.espresso:espresso-idling-resource:3.3.0-rc01'
-    androidTestImplementation "androidx.test:runner:1.3.0-rc01"
+    androidTestImplementation 'androidx.test:core:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-remote:3.3.0'
+    implementation 'androidx.test.espresso:espresso-idling-resource:3.3.0'
+    androidTestImplementation "androidx.test:runner:1.3.0"
 
     implementation project(':plugin-use-host-code-lib')
     implementation project(':test-manager')

--- a/projects/test/plugin/general-cases/general-cases-lib/build.gradle
+++ b/projects/test/plugin/general-cases/general-cases-lib/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'com.android.support:support-v4:27.1.1'
     implementation project(':custom-view')
 
-    compileOnly 'androidx.test.espresso:espresso-idling-resource:3.3.0-rc01'
+    compileOnly 'androidx.test.espresso:espresso-idling-resource:3.3.0'
 
     compileOnly project(':plugin-use-host-code-lib')
 }


### PR DESCRIPTION
主要目的是避免未来跳跃式升级版本不可行。