### PR TITLE
bugfix 防止重复subString导致.* .**规则失效

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoader.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoader.kt
@@ -105,26 +105,23 @@ private fun String.subStringBeforeDot() = substringBeforeLast('.', "")
 
 internal fun String.inPackage(packageNames: Array<String>): Boolean {
     val packageName = subStringBeforeDot()
-
     return packageNames.any {
         return@any when {
             it == "" -> false
             it == ".*" -> false
             it == ".**" -> false
             it.endsWith(".*") -> {//只允许一级子包
-                val sub = packageName.subStringBeforeDot()
-                if (sub.isEmpty()) {
+                if (packageName.isEmpty()) {
                     false
                 } else {
-                    sub == it.subStringBeforeDot()
+                    packageName == it.subStringBeforeDot()
                 }
             }
             it.endsWith(".**") -> {//允许所有子包
-                val sub = packageName.subStringBeforeDot()
-                if (sub.isEmpty()) {
+                if (packageName.isEmpty()) {
                     false
                 } else {
-                    "$sub.".startsWith(it.subStringBeforeDot() + '.')
+                    packageName.startsWith(it.subStringBeforeDot() + '.')
                 }
             }
             else -> packageName == it


### PR DESCRIPTION
PluginClassLoader.inPackage方法中如果使用了.* .**规则，会对当前加载的class包名调用2次subStringBeforeDot方法