### PR TITLE
fix(transform-kit): 自动创建缺失类时支持更多调用到fixTypes2的路径

### DIFF
--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AutoMakeMissingClassPool.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AutoMakeMissingClassPool.kt
@@ -5,6 +5,17 @@ import javassist.CtClass
 
 class AutoMakeMissingClassPool(useDefaultPath: Boolean) : ClassPool(useDefaultPath) {
 
+    companion object {
+        fun isFromFixTypes2Called(newThrowable: Throwable): Boolean {
+            for (stackTraceElement in newThrowable.stackTrace) {
+                if (stackTraceElement.methodName == "fixTypes2") {
+                    return true
+                }
+            }
+            return false
+        }
+    }
+
     override fun get0(classname: String?, useCache: Boolean): CtClass? {
         var get0 = super.get0(classname, useCache)
 
@@ -18,7 +29,7 @@ class AutoMakeMissingClassPool(useDefaultPath: Boolean) : ClassPool(useDefaultPa
         // 这里必须判断是来自的fixTypes2的调用，而不是所有调用都构造类型，是因为存在像
         // javassist.compiler.MemberResolver.lookupClass0
         // 依赖NotFoundException的逻辑存在。
-        if (get0 == null && Throwable().stackTrace[2].methodName == "fixTypes2") {
+        if (get0 == null && isFromFixTypes2Called(Throwable())) {
             get0 = makeClass(classname)
             if (useCache) cacheCtClass(get0.getName(), get0, false)
         }


### PR DESCRIPTION
之前有这样一种调用路径是没有考虑到的：
```
 0 = {StackTraceElement@21846} "com.tencent.shadow.core.transform_kit.AutoMakeMissingClassPool.get0(AutoMakeMissingClassPool.kt:9)"
 1 = {StackTraceElement@21847} "javassist.ClassPool.get(ClassPool.java:442)"
 2 = {StackTraceElement@21848} "javassist.CtClassType.getSuperclass(CtClassType.java:780)"
 3 = {StackTraceElement@21849} "javassist.bytecode.stackmap.TypeData.commonSuperClass(TypeData.java:519)"
 4 = {StackTraceElement@21850} "javassist.bytecode.stackmap.TypeData.commonSuperClassEx(TypeData.java:500)"
 5 = {StackTraceElement@21851} "javassist.bytecode.stackmap.TypeData$TypeVar.fixTypes2(TypeData.java:420)"
 ```

fix #451