### PR TITLE
ci: 添加Windows环境构建验证

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,20 @@
+name: Windows build check
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: buildSdk
+        run: ./gradlew buildSdk
+      - name: lintSdk
+        run: ./gradlew lintSdk
+      - name: build sample/source
+        run: ./gradlew build
+
+


### PR DESCRIPTION
因为构建环境所需的环境变量和sdk路径涉及一点unix和windows的区别，所以加上Windows环境的构建任务测试构建脚本的改动是否能在Windows上正常运行，弥补平时开发时没有Windows环境验证的问题。

#456