### PR TITLE
fix(dynamic.host): 判断PluginManager.apk变化时采用md5

### DIFF
--- a/projects/sdk/core/manager/src/main/java/com/tencent/shadow/core/manager/installplugin/InstalledDao.java
+++ b/projects/sdk/core/manager/src/main/java/com/tencent/shadow/core/manager/installplugin/InstalledDao.java
@@ -18,6 +18,7 @@
 
 package com.tencent.shadow.core.manager.installplugin;
 
+import android.annotation.SuppressLint;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
@@ -90,6 +91,7 @@ public class InstalledDao {
      * @param UUID  插件的发布id
      * @return 插件安装数据
      */
+    @SuppressLint("Range")
     public InstalledPlugin getInstalledPluginByUUID(String UUID) {
         SQLiteDatabase db = mDBHelper.getReadableDatabase();
         Cursor cursor = db.rawQuery("select * from shadowPluginManager where uuid = ?", new String[]{UUID});
@@ -155,6 +157,7 @@ public class InstalledDao {
      * @param limit 获取的数据数量
      * @return 插件列表数据
      */
+    @SuppressLint("Range")
     public List<InstalledPlugin> getLastPlugins(int limit) {
         SQLiteDatabase db = mDBHelper.getReadableDatabase();
         Cursor cursor = db.rawQuery("select uuid from shadowPluginManager where  type = ?   order by installedTime desc limit " + limit, new String[]{String.valueOf(InstalledType.TYPE_UUID)});

--- a/projects/sdk/core/manager/src/main/java/com/tencent/shadow/core/manager/installplugin/InstalledPluginDBHelper.java
+++ b/projects/sdk/core/manager/src/main/java/com/tencent/shadow/core/manager/installplugin/InstalledPluginDBHelper.java
@@ -19,6 +19,7 @@
 package com.tencent.shadow.core.manager.installplugin;
 
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
@@ -121,6 +122,7 @@ public class InstalledPluginDBHelper extends SQLiteOpenHelper {
     }
 
     @Override
+    @SuppressLint("Range")
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
         if (oldVersion < 2) {
             db.beginTransaction();


### PR DESCRIPTION
之前用的文件最后修改时间会在加载apk之后被android系统修改。
进而出现apk没有变化的情况下第2次调用enter时会执行更新Impl的流程。

这个Bug影响不大，因为是同一个Impl更新成一个新实例，Impl的state传给同一个实现应该是足够安全的。

此修复修改了dynamic.host，需要更新宿主中的代码。

fix #484