### PR TITLE
fix(core): 支持onActivityPreCreated方法

### DIFF
--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginActivity.java
@@ -46,6 +46,18 @@ public abstract class PluginActivity extends GeneratedPluginActivity {
 
     ComponentName mCallingActivity;
 
+    private ShadowActivityLifecycleCallbacks.Holder lifecycleCallbacksHolder;
+
+    public void registerActivityLifecycleCallbacks(
+            ShadowActivityLifecycleCallbacks callback) {
+        lifecycleCallbacksHolder.registerActivityLifecycleCallbacks(this, callback);
+    }
+
+    public void unregisterActivityLifecycleCallbacks(
+            ShadowActivityLifecycleCallbacks callback) {
+        lifecycleCallbacksHolder.unregisterActivityLifecycleCallbacks(callback);
+    }
+
     public final void setHostContextAsBase(Context context) {
         attachBaseContext(context);
     }
@@ -53,6 +65,7 @@ public abstract class PluginActivity extends GeneratedPluginActivity {
     public void setHostActivityDelegator(HostActivityDelegator delegator) {
         super.hostActivityDelegator = delegator;
         hostActivityDelegator = delegator;
+        lifecycleCallbacksHolder = new ShadowActivityLifecycleCallbacks.Holder(delegator);
     }
 
     public void setPluginApplication(ShadowApplication pluginApplication) {

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowActivity.java
@@ -18,7 +18,6 @@
 
 package com.tencent.shadow.core.runtime;
 
-import android.app.Application;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.content.IntentSender;
@@ -27,9 +26,6 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class ShadowActivity extends PluginActivity {
 
@@ -116,32 +112,6 @@ public class ShadowActivity extends PluginActivity {
             throw new IllegalArgumentException("ID does not reference a View inside this Activity");
         }
         return view;
-    }
-
-    final private Map<ShadowActivityLifecycleCallbacks,
-            Application.ActivityLifecycleCallbacks>
-            mActivityLifecycleCallbacksMap = new HashMap<>();
-
-    public void registerActivityLifecycleCallbacks(
-            ShadowActivityLifecycleCallbacks callback) {
-        synchronized (mActivityLifecycleCallbacksMap) {
-            final ShadowActivityLifecycleCallbacks.Wrapper wrapper
-                    = new ShadowActivityLifecycleCallbacks.Wrapper(callback, this);
-            mActivityLifecycleCallbacksMap.put(callback, wrapper);
-            hostActivityDelegator.registerActivityLifecycleCallbacks(wrapper);
-        }
-    }
-
-    public void unregisterActivityLifecycleCallbacks(
-            ShadowActivityLifecycleCallbacks callback) {
-        synchronized (mActivityLifecycleCallbacksMap) {
-            final Application.ActivityLifecycleCallbacks activityLifecycleCallbacks
-                    = mActivityLifecycleCallbacksMap.get(callback);
-            if (activityLifecycleCallbacks != null) {
-                hostActivityDelegator.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks);
-                mActivityLifecycleCallbacksMap.remove(callback);
-            }
-        }
     }
 
     @Override

--- a/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/ActivityLifecycleCallbacksTest.java
+++ b/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/ActivityLifecycleCallbacksTest.java
@@ -1,0 +1,74 @@
+package com.tencent.shadow.test.cases.plugin_main;
+
+import android.content.Intent;
+import android.os.Build;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.action.ViewActions;
+import androidx.test.espresso.matcher.ViewMatchers;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class ActivityLifecycleCallbacksTest extends PluginMainAppTest {
+
+    @Override
+    protected Intent getLaunchIntent() {
+        Intent pluginIntent = new Intent();
+        String packageName = ApplicationProvider.getApplicationContext().getPackageName();
+        pluginIntent.setClassName(
+                packageName,
+                "com.tencent.shadow.test.plugin.general_cases.lib.usecases.application.ActivityLifecycleCallbacksTestActivity"
+        );
+        return pluginIntent;
+    }
+
+
+    @Test
+    public void testRecreateRecord() {
+        Espresso.onView(ViewMatchers.withTagValue(Matchers.<Object>is("recreate")))
+                .perform(ViewActions.click());
+
+        String api29 = "[onActivityPreCreated, " +
+                "onActivityCreated, " +
+                "onActivityPostCreated, " +
+                "onActivityPreStarted, " +
+                "onActivityStarted, " +
+                "onActivityPostStarted, " +
+                "onActivityPreResumed, " +
+                "onActivityResumed, " +
+                "onActivityPostResumed, " +
+                "onActivityPrePaused, " +
+                "onActivityPaused, " +
+                "onActivityPostPaused, " +
+                "onActivityPreStopped, " +
+                "onActivityStopped, " +
+                "onActivityPostStopped, " +
+                "onActivityPreSaveInstanceState, " +
+                "onActivitySaveInstanceState, " +
+                "onActivityPostSaveInstanceState, " +
+                "onActivityPreDestroyed, " +
+                "onActivityDestroyed, " +
+                "onActivityPostDestroyed, " +
+                "onActivityPreCreated, " +
+                "onActivityCreated]";
+
+        String api28 = "[onActivityCreated, " +
+                "onActivityStarted, " +
+                "onActivityResumed, " +
+                "onActivityPaused, " +
+                "onActivityStopped, " +
+                "onActivitySaveInstanceState, " +
+                "onActivityDestroyed, " +
+                "onActivityCreated]";
+
+        String expect = Build.VERSION.SDK_INT < Build.VERSION_CODES.Q ? api28 : api29;
+
+        matchTextWithViewTag("ActivityCreateTest", expect);
+    }
+
+}

--- a/projects/test/plugin/general-cases/general-cases-app/src/androidTest/java/com/tencent/shadow/test/plugin/general_cases/app/ActivityLifecycleCallbacksTest.java
+++ b/projects/test/plugin/general-cases/general-cases-app/src/androidTest/java/com/tencent/shadow/test/plugin/general_cases/app/ActivityLifecycleCallbacksTest.java
@@ -1,0 +1,75 @@
+package com.tencent.shadow.test.plugin.general_cases.app;
+
+import android.content.Intent;
+import android.os.Build;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.action.ViewActions;
+import androidx.test.espresso.matcher.ViewMatchers;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class ActivityLifecycleCallbacksTest extends NormalAppTest {
+
+    @Before
+    public void launchActivity() {
+        Intent intent = new Intent();
+        String packageName = ApplicationProvider.getApplicationContext().getPackageName();
+        intent.setClassName(
+                packageName,
+                "com.tencent.shadow.test.plugin.general_cases.lib.usecases.application.ActivityLifecycleCallbacksTestActivity"
+        );
+        ActivityScenario.launch(intent);
+    }
+
+    @Test
+    public void testRecreateRecord() {
+        Espresso.onView(ViewMatchers.withTagValue(Matchers.<Object>is("recreate")))
+                .perform(ViewActions.click());
+
+        String api29 = "[onActivityPreCreated, " +
+                "onActivityCreated, " +
+                "onActivityPostCreated, " +
+                "onActivityPreStarted, " +
+                "onActivityStarted, " +
+                "onActivityPostStarted, " +
+                "onActivityPreResumed, " +
+                "onActivityResumed, " +
+                "onActivityPostResumed, " +
+                "onActivityPrePaused, " +
+                "onActivityPaused, " +
+                "onActivityPostPaused, " +
+                "onActivityPreStopped, " +
+                "onActivityStopped, " +
+                "onActivityPostStopped, " +
+                "onActivityPreSaveInstanceState, " +
+                "onActivitySaveInstanceState, " +
+                "onActivityPostSaveInstanceState, " +
+                "onActivityPreDestroyed, " +
+                "onActivityDestroyed, " +
+                "onActivityPostDestroyed, " +
+                "onActivityPreCreated, " +
+                "onActivityCreated]";
+
+        String api28 = "[onActivityCreated, " +
+                "onActivityStarted, " +
+                "onActivityResumed, " +
+                "onActivityPaused, " +
+                "onActivityStopped, " +
+                "onActivitySaveInstanceState, " +
+                "onActivityDestroyed, " +
+                "onActivityCreated]";
+
+        String expect = Build.VERSION.SDK_INT < Build.VERSION_CODES.Q ? api28 : api29;
+
+        matchTextWithViewTag("ActivityCreateTest", expect);
+    }
+
+}

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/AndroidManifest.xml
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/AndroidManifest.xml
@@ -85,6 +85,7 @@
         <activity android:name=".usecases.context.RegisterNullReceiverActivity" />
         <activity android:name=".usecases.dialog.TestAlertDialogActivity" />
         <activity android:name=".usecases.instrumentation.TestInstrumentationActivity" />
+        <activity android:name=".usecases.application.ActivityLifecycleCallbacksTestActivity" />
 
         <provider
             android:authorities="com.tencent.shadow.provider.test"

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/gallery/TestApplication.java
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/gallery/TestApplication.java
@@ -18,7 +18,14 @@
 
 package com.tencent.shadow.test.plugin.general_cases.lib.gallery;
 
+import android.app.Activity;
 import android.app.Application;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.util.LinkedList;
+import java.util.List;
 
 public class TestApplication extends Application {
 
@@ -26,14 +33,183 @@ public class TestApplication extends Application {
 
     public boolean isOnCreate;
 
+    final private TestActivityLifecycleCallbacks alc = new TestActivityLifecycleCallbacks(
+            "com.tencent.shadow.test.plugin.general_cases.lib.usecases.application.ActivityLifecycleCallbacksTestActivity");
+
     @Override
     public void onCreate() {
         sInstence = this;
         isOnCreate = true;
         super.onCreate();
+
+        registerActivityLifecycleCallbacks(alc);
     }
 
     public static TestApplication getInstance() {
         return sInstence;
+    }
+
+    public List<String> getTestActivityLifecycleCallbacksRecord() {
+        return alc.recordList;
+    }
+}
+
+class TestActivityLifecycleCallbacks implements Application.ActivityLifecycleCallbacks {
+    final private String targetActivityName;
+    final List<String> recordList = new LinkedList<>();
+
+    TestActivityLifecycleCallbacks(String targetActivityName) {
+        this.targetActivityName = targetActivityName;
+    }
+
+    private boolean isTargetActivity(Activity activity) {
+        return activity.getClass().getName().equals(targetActivityName);
+    }
+
+    @Override
+    public void onActivityPreCreated(@NonNull Activity activity, @Nullable Bundle savedInstanceState) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityPreCreated");
+        }
+    }
+
+    @Override
+    public void onActivityCreated(@NonNull Activity activity, @Nullable Bundle savedInstanceState) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityCreated");
+        }
+    }
+
+    @Override
+    public void onActivityPostCreated(@NonNull Activity activity, @Nullable Bundle savedInstanceState) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityPostCreated");
+        }
+    }
+
+    @Override
+    public void onActivityPreStarted(@NonNull Activity activity) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityPreStarted");
+        }
+    }
+
+    @Override
+    public void onActivityStarted(@NonNull Activity activity) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityStarted");
+        }
+    }
+
+    @Override
+    public void onActivityPostStarted(@NonNull Activity activity) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityPostStarted");
+        }
+    }
+
+    @Override
+    public void onActivityPreResumed(@NonNull Activity activity) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityPreResumed");
+        }
+    }
+
+    @Override
+    public void onActivityResumed(@NonNull Activity activity) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityResumed");
+        }
+    }
+
+    @Override
+    public void onActivityPostResumed(@NonNull Activity activity) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityPostResumed");
+        }
+    }
+
+    @Override
+    public void onActivityPrePaused(@NonNull Activity activity) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityPrePaused");
+        }
+    }
+
+    @Override
+    public void onActivityPaused(@NonNull Activity activity) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityPaused");
+        }
+    }
+
+    @Override
+    public void onActivityPostPaused(@NonNull Activity activity) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityPostPaused");
+        }
+    }
+
+    @Override
+    public void onActivityPreStopped(@NonNull Activity activity) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityPreStopped");
+        }
+    }
+
+    @Override
+    public void onActivityStopped(@NonNull Activity activity) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityStopped");
+        }
+    }
+
+    @Override
+    public void onActivityPostStopped(@NonNull Activity activity) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityPostStopped");
+        }
+    }
+
+    @Override
+    public void onActivityPreSaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityPreSaveInstanceState");
+        }
+    }
+
+    @Override
+    public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivitySaveInstanceState");
+        }
+    }
+
+    @Override
+    public void onActivityPostSaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityPostSaveInstanceState");
+        }
+    }
+
+    @Override
+    public void onActivityPreDestroyed(@NonNull Activity activity) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityPreDestroyed");
+        }
+    }
+
+    @Override
+    public void onActivityDestroyed(@NonNull Activity activity) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityDestroyed");
+        }
+    }
+
+    @Override
+    public void onActivityPostDestroyed(@NonNull Activity activity) {
+        if (isTargetActivity(activity)) {
+            recordList.add("onActivityPostDestroyed");
+        }
     }
 }

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/application/ActivityLifecycleCallbacksTestActivity.java
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/application/ActivityLifecycleCallbacksTestActivity.java
@@ -1,0 +1,54 @@
+package com.tencent.shadow.test.plugin.general_cases.lib.usecases.application;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+
+import com.tencent.shadow.test.plugin.general_cases.lib.gallery.TestApplication;
+import com.tencent.shadow.test.plugin.general_cases.lib.gallery.util.UiUtil;
+
+import java.util.List;
+
+/**
+ * 在
+ * com.tencent.shadow.test.plugin.general_cases.lib.gallery.TestApplication
+ * 中注册一个ActivityLifecycleCallbacks，专门监听
+ * com.tencent.shadow.test.plugin.general_cases.lib.usecases.application.TestApplicationActivity
+ * 的生命周期。
+ * 然后用这个Activity打印出监听记录进行测试。
+ */
+public class ActivityLifecycleCallbacksTestActivity extends Activity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ViewGroup viewGroup = UiUtil.setActivityContentView(this);
+
+        List<String> record = TestApplication.getInstance().getTestActivityLifecycleCallbacksRecord();
+
+
+        viewGroup.addView(
+                UiUtil.makeItem(
+                        this,
+                        "ActivityCreateTest",
+                        "ActivityCreateTest",
+                        record.toString()
+                )
+        );
+
+        Button recreateButton = new Button(this);
+        recreateButton.setText("recreate");
+        recreateButton.setTag("recreate");
+        recreateButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                ActivityLifecycleCallbacksTestActivity.this.recreate();
+            }
+        });
+        viewGroup.addView(recreateButton);
+    }
+
+}


### PR DESCRIPTION
API 29以上ActivityLifecycleCallbacks有一个默认实现的接口onActivityPreCreated，
这个方法回调早于onCreate方法，也是唯一一个。此时PluginActivity尚未构造，因此不能正常工作。

统一ActivityLifecycleCallbacks映射实现到ShadowActivityLifecycleCallbacks.Holder，
由它持有所有ActivityLifecycleCallbacks。
ShadowActivityDelegate在PluginActivity onCreate之前通知Holder分发onActivityPreCreated事件。

close #505
close #519
fixup 0e5d9d8d