### PR TITLE
fix(core.loader): PluginClassLoader按双亲委派逻辑优先从specialClassLoader加载

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoader.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/classloaders/PluginClassLoader.kt
@@ -78,13 +78,13 @@ class PluginClassLoader(
             if (clazz == null) {
                 var suppressed: ClassNotFoundException? = null
                 try {
-                    clazz = findClass(className)!!
+                    clazz = specialClassLoader.loadClass(className)!!
                 } catch (e: ClassNotFoundException) {
                     suppressed = e
                 }
                 if (clazz == null) {
                     try {
-                        clazz = specialClassLoader.loadClass(className)!!
+                        clazz = findClass(className)!!
                     } catch (e: ClassNotFoundException) {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
                             e.addSuppressed(suppressed)

--- a/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/BootClassloaderTest.java
+++ b/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/BootClassloaderTest.java
@@ -1,0 +1,52 @@
+/*
+ * Tencent is pleased to support the open source community by making Tencent Shadow available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.tencent.shadow.test.cases.plugin_main;
+
+import android.content.Intent;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class BootClassloaderTest extends PluginMainAppTest {
+
+    @Override
+    protected Intent getLaunchIntent() {
+        Intent pluginIntent = new Intent();
+        String packageName = ApplicationProvider.getApplicationContext().getPackageName();
+        pluginIntent.setClassName(
+                packageName,
+                "com.tencent.shadow.test.plugin.general_cases.lib.usecases.classloader.TestBootClassloaderActivity"
+        );
+        return pluginIntent;
+    }
+
+    @Test
+    public void testBasicUsage() {
+
+        matchTextWithViewTag("xmlPullParserFrom", "java.lang.BootClassLoader");
+    }
+
+}

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/AndroidManifest.xml
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/AndroidManifest.xml
@@ -86,6 +86,7 @@
         <activity android:name=".usecases.dialog.TestAlertDialogActivity" />
         <activity android:name=".usecases.instrumentation.TestInstrumentationActivity" />
         <activity android:name=".usecases.application.ActivityLifecycleCallbacksTestActivity" />
+        <activity android:name=".usecases.classloader.TestBootClassloaderActivity" />
 
         <provider
             android:authorities="com.tencent.shadow.provider.test"

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/classloader/TestBootClassloaderActivity.java
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/classloader/TestBootClassloaderActivity.java
@@ -1,0 +1,57 @@
+/*
+ * Tencent is pleased to support the open source community by making Tencent Shadow available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.tencent.shadow.test.plugin.general_cases.lib.usecases.classloader;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.ViewGroup;
+
+import com.tencent.shadow.test.plugin.general_cases.lib.gallery.util.UiUtil;
+
+/**
+ * 插件中自己声明了一个和系统类重名的类org.xmlpull.v1.XmlPullParser
+ * 测试在插件环境下加载它是从哪个ClassLoader加载的
+ */
+public class TestBootClassloaderActivity extends Activity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ViewGroup viewGroup = UiUtil.setActivityContentView(this);
+
+        String xmlPullParserFrom;
+        try {
+            xmlPullParserFrom = getClassLoader().loadClass("org.xmlpull.v1.XmlPullParser")
+                    .getClassLoader().getClass().getName();
+        } catch (ClassNotFoundException e) {
+            xmlPullParserFrom = "ClassNotFoundException";
+        }
+
+        viewGroup.addView(
+                UiUtil.makeItem(
+                        this,
+                        "xmlPullParserFrom",
+                        "xmlPullParserFrom",
+                        xmlPullParserFrom
+                )
+        );
+    }
+
+}

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/java/org/xmlpull/v1/XmlPullParser.java
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/java/org/xmlpull/v1/XmlPullParser.java
@@ -1,0 +1,5 @@
+package org.xmlpull.v1;
+
+// 这个类和系统类重名，在插件中不应该被加载到
+public interface XmlPullParser {
+}


### PR DESCRIPTION
specialClassLoader通常是PathClassLoader的parent，可能是DynamicRuntimeClassLoader，也可能是BootClassLoader。

从specialClassLoader优先加载，使插件在打包了和系统类的重名类时，优先使用系统实现，与正常安装app保持一致。

fix #529