### PR TITLE
build: jvmTestSdk执行core :loader:test

### DIFF
--- a/buildScripts/gradle/maven.gradle
+++ b/buildScripts/gradle/maven.gradle
@@ -39,6 +39,7 @@ task jvmTestSdk() {
     dependsOn gradle.includedBuild('core').task(':transform:test')
     dependsOn gradle.includedBuild('core').task(':gradle-plugin:test')
     dependsOn gradle.includedBuild('core').task(':utils:test')
+    dependsOn gradle.includedBuild('core').task(':loader:test')
     dependsOn ':test_third-party-transform_androidx:assembleDebug'
 }
 


### PR DESCRIPTION
否则PluginClassLoaderTest执行不到。

#439 导致2个测试用例失败没测出来。