### PR TITLE
fix(core): LayoutInflater.getFactory()行为保持和正常app一致

### DIFF
--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowLayoutInflater.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowLayoutInflater.java
@@ -29,6 +29,36 @@ import android.view.LayoutInflater;
  */
 public class ShadowLayoutInflater extends ShadowWebViewLayoutInflater {
 
+    private Factory mOriginalFactory = null;
+    private Factory2 mOriginalFactory2 = null;
+
+    @Override
+    public void setFactory(Factory factory) {
+        mOriginalFactory = factory;
+        super.setFactory(factory);
+    }
+
+    @Override
+    public void setFactory2(Factory2 factory) {
+        mOriginalFactory = mOriginalFactory2 = factory;
+        super.setFactory2(factory);
+    }
+
+    public static Factory getOriginalFactory(LayoutInflater inflater) {
+        if (inflater instanceof ShadowLayoutInflater) {
+            return ((ShadowLayoutInflater) inflater).mOriginalFactory;
+        } else {
+            return inflater.getFactory();
+        }
+    }
+
+    public static Factory2 getOriginalFactory2(LayoutInflater inflater) {
+        if (inflater instanceof ShadowLayoutInflater) {
+            return ((ShadowLayoutInflater) inflater).mOriginalFactory2;
+        } else {
+            return inflater.getFactory2();
+        }
+    }
 
     public static ShadowLayoutInflater build(LayoutInflater original, Context newContext, String partKey) {
         InnerInflater innerLayoutInflater = new InnerInflater(original, newContext, partKey);

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/TransformManager.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/TransformManager.kt
@@ -43,6 +43,7 @@ class TransformManager(ctClassInputMap: Map<CtClass, InputClass>,
             PackageManagerTransform(),
             PackageItemInfoTransform(),
             AppComponentFactoryTransform(),
+            LayoutInflaterTransform(),
             KeepHostContextTransform(useHostContext())
     )
 }

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/LayoutInflaterTransform.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/LayoutInflaterTransform.kt
@@ -1,0 +1,61 @@
+package com.tencent.shadow.core.transform.specific
+
+import com.tencent.shadow.core.transform_kit.SpecificTransform
+import com.tencent.shadow.core.transform_kit.TransformStep
+import javassist.CodeConverter
+import javassist.CtClass
+import javassist.bytecode.Descriptor
+
+class LayoutInflaterTransform : SpecificTransform() {
+    companion object {
+        const val ShadowLayoutInflaterClassname =
+            "com.tencent.shadow.core.runtime.ShadowLayoutInflater"
+        const val AndroidLayoutInflaterClassname = "android.view.LayoutInflater"
+        const val LayoutInflaterFactoryClassname = "android.view.LayoutInflater\$Factory"
+        const val LayoutInflaterFactory2Classname = "android.view.LayoutInflater\$Factory2"
+    }
+
+    override fun setup(allInputClass: Set<CtClass>) {
+
+        val androidLayoutInflaterClass = mClassPool[AndroidLayoutInflaterClassname]
+        val shadowLayoutInflaterClass = mClassPool[ShadowLayoutInflaterClassname]
+        val layoutInflaterFactoryClass = mClassPool[LayoutInflaterFactoryClassname]
+        val layoutInflaterFactory2Class = mClassPool[LayoutInflaterFactory2Classname]
+
+        val getFactoryMethod = androidLayoutInflaterClass.getMethod(
+            "getFactory",
+            Descriptor.ofMethod(layoutInflaterFactoryClass, null)
+        )
+        val getFactory2Method = androidLayoutInflaterClass.getMethod(
+            "getFactory2",
+            Descriptor.ofMethod(layoutInflaterFactory2Class, null)
+        )
+        val getOriginalFactoryMethod = shadowLayoutInflaterClass.getMethod(
+            "getOriginalFactory",
+            Descriptor.ofMethod(layoutInflaterFactoryClass, arrayOf(androidLayoutInflaterClass))
+        )
+        val getOriginalFactory2Method = shadowLayoutInflaterClass.getMethod(
+            "getOriginalFactory2",
+            Descriptor.ofMethod(layoutInflaterFactory2Class, arrayOf(androidLayoutInflaterClass))
+        )
+
+        val codeConverter = CodeConverter()
+        codeConverter.redirectMethodCallToStatic(getFactoryMethod, getOriginalFactoryMethod)
+        codeConverter.redirectMethodCallToStatic(getFactory2Method, getOriginalFactory2Method)
+
+        newStep(object : TransformStep {
+            override fun filter(allInputClass: Set<CtClass>) =
+                filterRefClasses(allInputClass, listOf(AndroidLayoutInflaterClassname))
+
+            override fun transform(ctClass: CtClass) {
+                try {
+                    ctClass.instrument(codeConverter)
+                } catch (e: Exception) {
+                    System.err.println("处理" + ctClass.name + "时出错")
+                    throw e
+                }
+            }
+        })
+    }
+
+}

--- a/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/LayoutInflaterTest.java
+++ b/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/LayoutInflaterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Tencent is pleased to support the open source community by making Tencent Shadow available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.tencent.shadow.test.cases.plugin_main;
+
+import android.content.Intent;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class LayoutInflaterTest extends PluginMainAppTest {
+
+    @Override
+    protected Intent getLaunchIntent() {
+        Intent pluginIntent = new Intent();
+        String packageName = ApplicationProvider.getApplicationContext().getPackageName();
+        pluginIntent.setClassName(
+                packageName,
+                "com.tencent.shadow.test.plugin.general_cases.lib.usecases.context.TestLayoutInflaterActivity"
+        );
+        return pluginIntent;
+    }
+
+    @Test
+    public void testFactoryClassNameBeforeSet() {
+        matchTextWithViewTag("FactoryClassNameBeforeSet", "null");
+    }
+
+    @Test
+    public void testFactoryClassNameAfterSet() {
+        matchTextWithViewTag("FactoryClassNameAfterSet", "com.tencent.shadow.test.plugin.general_cases.lib.usecases.context.TestFactory2");
+    }
+}

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/AndroidManifest.xml
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/AndroidManifest.xml
@@ -87,6 +87,7 @@
         <activity android:name=".usecases.instrumentation.TestInstrumentationActivity" />
         <activity android:name=".usecases.application.ActivityLifecycleCallbacksTestActivity" />
         <activity android:name=".usecases.classloader.TestBootClassloaderActivity" />
+        <activity android:name=".usecases.context.TestLayoutInflaterActivity" />
 
         <provider
             android:authorities="com.tencent.shadow.provider.test"

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/context/TestLayoutInflaterActivity.java
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/context/TestLayoutInflaterActivity.java
@@ -1,0 +1,86 @@
+/*
+ * Tencent is pleased to support the open source community by making Tencent Shadow available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.tencent.shadow.test.plugin.general_cases.lib.usecases.context;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.tencent.shadow.test.plugin.general_cases.lib.gallery.util.UiUtil;
+
+public class TestLayoutInflaterActivity extends Activity {
+
+    private ViewGroup mItemViewGroup;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mItemViewGroup = UiUtil.setActivityContentView(this);
+
+        mItemViewGroup.addView(
+                UiUtil.makeItem(
+                        this,
+                        "FactoryClassNameBeforeSet",
+                        "FactoryClassNameBeforeSet",
+                        getFactoryClassName(getLayoutInflater())
+                )
+        );
+
+        LayoutInflater layoutInflater = getLayoutInflater();
+        layoutInflater.setFactory2(new TestFactory2());
+        mItemViewGroup.addView(
+                UiUtil.makeItem(
+                        this,
+                        "FactoryClassNameAfterSet",
+                        "FactoryClassNameAfterSet",
+                        getFactoryClassName(layoutInflater)
+                )
+        );
+    }
+
+    private static String getFactoryClassName(LayoutInflater layoutInflater) {
+        LayoutInflater.Factory factory = layoutInflater.getFactory();
+        if (factory == null) {
+            return "null";
+        } else {
+            return factory.getClass().getName();
+        }
+    }
+}
+
+class TestFactory2 implements LayoutInflater.Factory2 {
+
+    @Nullable
+    @Override
+    public View onCreateView(@Nullable View parent, @NonNull String name, @NonNull Context context, @NonNull AttributeSet attrs) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull String name, @NonNull Context context, @NonNull AttributeSet attrs) {
+        return null;
+    }
+}


### PR DESCRIPTION
AppCompat有一个installViewFactory逻辑，依赖于判断layoutInflater.getFactory() == null才正常安装。
而ShadowLayoutInflater已经设置了Factory，所以对于插件代码来说，虽然还能够setFactory，
但是getFactory()返回的就不是null了。

添加一个Transform，将插件中原本的getFactory()修改为ShadowLayoutInflater.getOriginalFactory，
从而保持插件代码getFactory()时总能获取到自己原本设置的Factory。

fix #214