### PR TITLE
chore: 统一所有sample的AGP到4.0.2版本

### DIFF
--- a/projects/sample/maven/host-project/build.gradle
+++ b/projects/sample/maven/host-project/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/projects/sample/maven/host-project/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/sample/maven/host-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-#distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
-distributionUrl=https\://mirrors.tencent.com/gradle/gradle-5.6.4-bin.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://mirrors.tencent.com/gradle/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/projects/sample/maven/manager-project/build.gradle
+++ b/projects/sample/maven/manager-project/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/projects/sample/maven/manager-project/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/sample/maven/manager-project/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-#distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
-distributionUrl=https\://mirrors.tencent.com/gradle/gradle-5.6.4-all.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://mirrors.tencent.com/gradle/gradle-6.6.1-bin.zip

--- a/projects/sample/maven/plugin-project/build.gradle
+++ b/projects/sample/maven/plugin-project/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/projects/sample/maven/plugin-project/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/sample/maven/plugin-project/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-#distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
-distributionUrl=https\://mirrors.tencent.com/gradle/gradle-5.6.4-all.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://mirrors.tencent.com/gradle/gradle-6.6.1-bin.zip

--- a/projects/sample/sunflower/plugin-project/build.gradle
+++ b/projects/sample/sunflower/plugin-project/build.gradle
@@ -31,7 +31,7 @@ buildscript {
         espressoVersion = '3.1.1'
         fragmentVersion = '1.1.0-alpha09'
         glideVersion = '4.9.0'
-        gradleVersion = '3.5.1'
+        gradleVersion = '4.0.2'
         gsonVersion = '2.8.2'
         junitVersion = '4.12'
         kotlinVersion = '1.3.41'


### PR DESCRIPTION
避免4.0.0以下版本生成没有<application />的apk，在targetSdkVersion>=30时，在API 30以上的手机上Crash。

#582