### PR TITLE
feat(core.transform): ShadowTransform声明为支持build cache

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,6 +12,14 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: buildSdk
         run: ./gradlew wrapper; ./gradlew buildSdk
       - name: lintSdk
@@ -29,6 +37,8 @@ jobs:
           arch: x86_64
           profile: pixel_xl
           script: ./gradlew wrapper; ./gradlew androidTestSdk
+      - name: stop gradle deamon for actions/cache
+        run: ./gradlew --stop
   build-on-windows:
     runs-on: windows-latest
     env:
@@ -36,12 +46,22 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: buildSdk
         run: ./gradlew wrapper; ./gradlew buildSdk
       - name: lintSdk
         run: ./gradlew wrapper; ./gradlew lintSdk
       - name: build sample/source
         run: ./gradlew wrapper; ./gradlew build
+      - name: stop gradle deamon for actions/cache
+        run: ./gradlew --stop
   build-samples:
     runs-on: ubuntu-latest
     env:
@@ -49,6 +69,14 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: build sample/maven/host-project
         working-directory: projects/sample/maven/host-project
         run: ./gradlew wrapper; ./gradlew assemble
@@ -67,3 +95,5 @@ jobs:
       - name: build sample/sunflower/plugin-project
         working-directory: projects/sample/sunflower/plugin-project
         run: ./gradlew wrapper; ./gradlew assemble
+      - name: stop gradle deamon for actions/cache
+        run: ./gradlew --stop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,14 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: buildSdk
         run: ./gradlew wrapper; ./gradlew buildSdk
       - name: lintSdk
@@ -30,6 +38,8 @@ jobs:
           arch: x86_64
           profile: pixel_xl
           script: ./gradlew wrapper; ./gradlew androidTestSdk
+      - name: stop gradle deamon for actions/cache
+        run: ./gradlew --stop
   publish:
     needs: build-and-test
     runs-on: macos-latest
@@ -42,5 +52,15 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
       - name: checkout
         uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: publish
         run: ./gradlew wrapper; ./gradlew publish
+      - name: stop gradle deamon for actions/cache
+        run: ./gradlew --stop

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,5 @@ org.gradle.jvmargs=-Xmx4096m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 android.useAndroidX=true
+org.gradle.caching=true
+

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/ShadowTransform.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/ShadowTransform.kt
@@ -40,5 +40,9 @@ class ShadowTransform(
         _mTransformManager = TransformManager(mCtClassInputMap, classPool, useHostContext)
     }
 
+    override fun isCacheable(): Boolean {
+        return true
+    }
+
     override fun getName(): String = "ShadowTransform"
 }


### PR DESCRIPTION
由于ShadowTransform只处理输入的文件，并且处理时逻辑固定。在输入文件不变的情况下，输出文件总是可替代的。所以直接声明isCacheable为true就可以使用构建缓存。

同时开启Github Action上的缓存机制，加快构建。