### PR TITLE
fix(core.transform-kit): Transform启动前清空debug用的临时目录

### DIFF
--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransform.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransform.kt
@@ -41,6 +41,7 @@ abstract class AbstractTransform(
 
     private fun cleanDebugClassFileDir() {
         val transformTempDir = File(project.buildDir, "transform-temp")
+        transformTempDir.deleteRecursively()
         transformTempDir.mkdirs()
         mDebugClassJar = File.createTempFile("transform-temp", ".jar", transformTempDir)
         mDebugClassJarZOS = ZipOutputStream(FileOutputStream(mDebugClassJar))


### PR DESCRIPTION
否则该目录不断产生临时文件，build目录持续增大。