### PR TITLE
fix(core): 插件的LayoutInflater改为总是从Context取单例

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/delegates/ShadowActivityDelegate.kt
@@ -21,7 +21,6 @@ package com.tencent.shadow.core.loader.delegates
 import android.app.Activity
 import android.content.ComponentName
 import android.content.Context
-import android.content.Context.LAYOUT_INFLATER_SERVICE
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
@@ -40,7 +39,10 @@ import com.tencent.shadow.core.loader.managers.ComponentManager.Companion.CM_CLA
 import com.tencent.shadow.core.loader.managers.ComponentManager.Companion.CM_EXTRAS_BUNDLE_KEY
 import com.tencent.shadow.core.loader.managers.ComponentManager.Companion.CM_LOADER_BUNDLE_KEY
 import com.tencent.shadow.core.loader.managers.ComponentManager.Companion.CM_PART_KEY
-import com.tencent.shadow.core.runtime.*
+import com.tencent.shadow.core.runtime.MixResources
+import com.tencent.shadow.core.runtime.PluginActivity
+import com.tencent.shadow.core.runtime.ShadowActivity
+import com.tencent.shadow.core.runtime.ShadowActivityLifecycleCallbacks
 import com.tencent.shadow.core.runtime.container.HostActivityDelegate
 import com.tencent.shadow.core.runtime.container.HostActivityDelegator
 
@@ -250,10 +252,7 @@ open class ShadowActivityDelegate(private val mDI: DI) : GeneratedShadowActivity
         return mPluginClassLoader
     }
 
-    override fun getLayoutInflater(): LayoutInflater {
-        val inflater = mHostActivityDelegator.applicationContext.getSystemService(LAYOUT_INFLATER_SERVICE) as LayoutInflater
-        return ShadowLayoutInflater.build(inflater, mPluginActivity, mPartKey)
-    }
+    override fun getLayoutInflater(): LayoutInflater = LayoutInflater.from(mPluginActivity)
 
     override fun getResources(): Resources {
         if (mDependenciesInjected) {

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginActivity.java
@@ -81,8 +81,7 @@ public abstract class PluginActivity extends GeneratedPluginActivity {
     }
 
     public LayoutInflater getLayoutInflater() {
-        LayoutInflater inflater = hostActivityDelegator.getWindow().getLayoutInflater();
-        return ShadowLayoutInflater.build(inflater, this, mPartKey);
+        return LayoutInflater.from(this);
     }
 
     //TODO: 对齐原手工代码，这个方法签名实际上不对，应该传入ShadowActivity

--- a/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_androidx/AppCompatActivityTest.java
+++ b/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_androidx/AppCompatActivityTest.java
@@ -1,0 +1,51 @@
+/*
+ * Tencent is pleased to support the open source community by making Tencent Shadow available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.tencent.shadow.test.cases.plugin_androidx;
+
+import android.content.Intent;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class AppCompatActivityTest extends PluginAndroidxAppTest {
+
+    @Override
+    protected Intent getLaunchIntent() {
+        Intent pluginIntent = new Intent();
+        String packageName = ApplicationProvider.getApplicationContext().getPackageName();
+        pluginIntent.setClassName(
+                packageName,
+                "com.tencent.shadow.test.plugin.androidx_cases.lib.AppCompatTestActivity"
+        );
+        return pluginIntent;
+    }
+
+    @Test
+    public void testFactory2Class() {
+        matchTextWithViewTag("factory2Class", "androidx.appcompat.app.AppCompatDelegateImpl");
+    }
+
+}

--- a/projects/test/plugin/androidx-cases/androidx-cases-lib/build.gradle
+++ b/projects/test/plugin/androidx-cases/androidx-cases-lib/build.gradle
@@ -27,6 +27,8 @@ android {
 
 dependencies {
     def activity_version = "1.2.2"
+    def appcompat_version = "1.3.1"
 
     implementation "androidx.activity:activity:$activity_version"
+    implementation "androidx.appcompat:appcompat:$appcompat_version"
 }

--- a/projects/test/plugin/androidx-cases/androidx-cases-lib/src/main/AndroidManifest.xml
+++ b/projects/test/plugin/androidx-cases/androidx-cases-lib/src/main/AndroidManifest.xml
@@ -9,5 +9,8 @@
 
         <activity android:name=".LiveDataWithActivityTestActivity" />
         <activity android:name=".AppComponentFactoryTestActivity" />
+        <activity
+            android:name=".AppCompatTestActivity"
+            android:theme="@style/Theme.AppCompat" />
     </application>
 </manifest>

--- a/projects/test/plugin/androidx-cases/androidx-cases-lib/src/main/java/com/tencent/shadow/test/plugin/androidx_cases/lib/AppCompatTestActivity.java
+++ b/projects/test/plugin/androidx-cases/androidx-cases-lib/src/main/java/com/tencent/shadow/test/plugin/androidx_cases/lib/AppCompatTestActivity.java
@@ -1,0 +1,33 @@
+package com.tencent.shadow.test.plugin.androidx_cases.lib;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+public class AppCompatTestActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        LayoutInflater.Factory2 factory2 = getLayoutInflater().getFactory2();
+        String factory2Class;
+        if (factory2 == null) {
+            factory2Class = "null";
+        } else {
+            factory2Class = factory2.getClass().getName();
+        }
+
+        ViewGroup viewGroup = UiUtil.setActivityContentView(this);
+        ViewGroup item = UiUtil.makeItem(
+                this,
+                "factory2Class",
+                "factory2Class",
+                factory2Class
+        );
+
+        viewGroup.addView(item);
+    }
+}


### PR DESCRIPTION
由于ShadowLayoutInflater不再只是一个转调壳子，有了状态（mOriginalFactory等），
不能再总是new新的对象了。换了新对象就无法还原Factory了。

fixup! c710a18
fix #614