### PR TITLE
fix(core.transform): newMethod引用当前类名时使用Placeholder

### DIFF
--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/ShadowTransform.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/ShadowTransform.kt
@@ -29,6 +29,10 @@ class ShadowTransform(
         classPoolBuilder: ClassPoolBuilder,
         private val useHostContext: () -> Array<String>
 ) : AbstractTransform(project, classPoolBuilder) {
+    companion object {
+        const val SelfClassNamePlaceholder =
+            "com.tencent.shadow.core.transform.SelfClassNamePlaceholder"
+    }
 
     lateinit var _mTransformManager: TransformManager
 
@@ -38,6 +42,7 @@ class ShadowTransform(
     override fun beforeTransform(invocation: TransformInvocation) {
         super.beforeTransform(invocation)
         _mTransformManager = TransformManager(mCtClassInputMap, classPool, useHostContext)
+        classPool.makeInterface(SelfClassNamePlaceholder)
     }
 
     override fun isCacheable(): Boolean {

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/PackageItemInfoTransform.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/PackageItemInfoTransform.kt
@@ -18,6 +18,7 @@
 
 package com.tencent.shadow.core.transform.specific
 
+import com.tencent.shadow.core.transform.ShadowTransform.Companion.SelfClassNamePlaceholder
 import com.tencent.shadow.core.transform_kit.SpecificTransform
 import com.tencent.shadow.core.transform_kit.TransformStep
 import javassist.*
@@ -76,7 +77,7 @@ class PackageItemInfoTransform : SpecificTransform() {
                                 .append(".")
                                 .append(targetMethod.methodInfo.name)
                                 .append("(")
-                                .append(ctClass.name)
+                                .append(SelfClassNamePlaceholder)
                                 .append(".class.getClassLoader(),")
                         for (i in 1..newMethod.parameterTypes.size) {
                             if (i > 1) {
@@ -88,6 +89,7 @@ class PackageItemInfoTransform : SpecificTransform() {
 
                         newMethod.setBody(newBodyBuilder.toString())
                         ctClass.addMethod(newMethod)
+                        ctClass.replaceClassName(SelfClassNamePlaceholder,ctClass.name)
                         val codeConverter = CodeConverter()
                         codeConverter.redirectMethodCallToStatic(targetMethod, newMethod)
                         ctClass.instrument(codeConverter)

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/PackageManagerTransform.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/PackageManagerTransform.kt
@@ -18,6 +18,7 @@
 
 package com.tencent.shadow.core.transform.specific
 
+import com.tencent.shadow.core.transform.ShadowTransform.Companion.SelfClassNamePlaceholder
 import com.tencent.shadow.core.transform_kit.SpecificTransform
 import com.tencent.shadow.core.transform_kit.TransformStep
 import javassist.*
@@ -66,7 +67,7 @@ class PackageManagerTransform : SpecificTransform() {
                                 .append(".")
                                 .append(targetMethod.methodInfo.name)
                                 .append("(")
-                                .append(ctClass.name)
+                                .append(SelfClassNamePlaceholder)
                                 .append(".class.getClassLoader(),")
                         //下面放弃第0个和第1个参数，第0个是this，
                         //第1个是redirectMethodCallToStaticMethodCall时原本被调用的PackageManager对象。
@@ -80,6 +81,7 @@ class PackageManagerTransform : SpecificTransform() {
 
                         newMethod.setBody(newBodyBuilder.toString())
                         ctClass.addMethod(newMethod)
+                        ctClass.replaceClassName(SelfClassNamePlaceholder, ctClass.name)
                         val codeConverter = CodeConverter()
                         codeConverter.redirectMethodCallToStatic(targetMethod, newMethod)
                         ctClass.instrument(codeConverter)

--- a/projects/sdk/core/transform/src/test/kotlin/com/tencent/shadow/core/transform/specific/PackageManagerTransformTest.kt
+++ b/projects/sdk/core/transform/src/test/kotlin/com/tencent/shadow/core/transform/specific/PackageManagerTransformTest.kt
@@ -18,6 +18,7 @@
 
 package com.tencent.shadow.core.transform.specific
 
+import com.tencent.shadow.core.transform.ShadowTransform.Companion.SelfClassNamePlaceholder
 import com.tencent.shadow.core.transform_kit.AbstractTransformTest
 import javassist.CtClass
 import javassist.CtMethod
@@ -34,12 +35,16 @@ class PackageManagerTransformTest : AbstractTransformTest() {
 
         val packageManagerTransform = PackageManagerTransform()
         packageManagerTransform.mClassPool = sLoader
+        packageManagerTransform.mClassPool.makeInterface(SelfClassNamePlaceholder)
         packageManagerTransform.setup(allInputClass)
 
         val methods = arrayOf("getApplicationInfo","getActivityInfo")
 
 
         allInputClass.forEach {
+            //将测试类的包名改为Java的非法包名字符，测试Proguard混淆成这种形式的jar的场景
+            it.name = "1.${it.simpleName}"
+
             for (method in methods) {
                 beforeTransformCheck(it, method)
             }


### PR DESCRIPTION
修复前对于PackageManagerTransformTest.kt改动的情况无法编译成功。因为setBody时需要编译Java代码片段。存在一些经过Proguard混淆的类使用了非法的字符作为包名，在代码里引用这些类名无法正常编译。

需要引用当前类的class时，先引用这个Placeholder，编译后再直接通过字节码修改替换回原来的名字。

fix #623