### PR TITLE
fix(transform-kit): debugWriteJar时忽略META-INF/目录文件

### DIFF
--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransform.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransform.kt
@@ -76,20 +76,19 @@ abstract class AbstractTransform(
         onCheckTransformedClasses(debugClassPool, inputClassNames)
     }
 
-    override fun onOutputClass(className: String, outputStream: OutputStream) {
-        classPool[className].debugWriteJar(mDebugClassJarZOS)
-        super.onOutputClass(className, outputStream)
+    override fun onOutputClass(entryName: String?, className: String, outputStream: OutputStream) {
+        classPool[className].debugWriteJar(entryName, mDebugClassJarZOS)
+        super.onOutputClass(entryName, className, outputStream)
     }
 
-    private fun CtClass.debugWriteJar(outputStream: ZipOutputStream) {
-        //忽略Kotlin 1.4引入的module-info
-        //https://kotlinlang.org/docs/reference/whatsnew14.html#module-info-descriptors-for-stdlib-artifacts
-        if (name == "module-info") {
+    private fun CtClass.debugWriteJar(outputEntryName: String?, outputStream: ZipOutputStream) {
+        //忽略META-INF
+        if (outputEntryName?.startsWith("META-INF/") == true) {
             return
         }
 
         try {
-            val entryName = (name.replace('.', '/') + ".class")
+            val entryName = outputEntryName ?: (name.replace('.', '/') + ".class")
             outputStream.putNextEntry(ZipEntry(entryName))
             val p = stopPruning(true)
             toBytecode(DataOutputStream(outputStream))

--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/ClassTransform.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/ClassTransform.kt
@@ -114,7 +114,7 @@ abstract class ClassTransform(val project: Project) : Transform() {
                             val file = it.second
                             Files.createParentDirs(file)
                             FileOutputStream(file).use {
-                                onOutputClass(className, it)
+                                onOutputClass(null, className, it)
                             }
                         }
                     }
@@ -129,7 +129,7 @@ abstract class ClassTransform(val project: Project) : Transform() {
                                 val className = it.first
                                 val entryName = it.second
                                 zos.putNextEntry(ZipEntry(entryName))
-                                onOutputClass(className, zos)
+                                onOutputClass(entryName, className, zos)
                             }
                         }
                     }
@@ -138,7 +138,7 @@ abstract class ClassTransform(val project: Project) : Transform() {
         }
     }
 
-    abstract fun onOutputClass(className: String, outputStream: OutputStream)
+    abstract fun onOutputClass(entryName: String?, className: String, outputStream: OutputStream)
 
     abstract fun DirInputClass.onInputClass(classFile: File, outputFile: File)
 

--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/JavassistTransform.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/JavassistTransform.kt
@@ -30,7 +30,7 @@ open class JavassistTransform(project: Project, val classPoolBuilder: ClassPoolB
     val mCtClassInputMap = mutableMapOf<CtClass, InputClass>()
     lateinit var classPool: ClassPool
 
-    override fun onOutputClass(className: String, outputStream: OutputStream) {
+    override fun onOutputClass(entryName: String?, className: String, outputStream: OutputStream) {
         classPool[className].writeOut(outputStream)
     }
 


### PR DESCRIPTION
同时采用output时相同的entryName。

fix #641