### PR TITLE
fix(core): 支持Fragment override getContext方法

### DIFF
--- a/projects/sdk/core/transform-kit/src/main/java/javassist/EnhancedCodeConverter.java
+++ b/projects/sdk/core/transform-kit/src/main/java/javassist/EnhancedCodeConverter.java
@@ -1,0 +1,11 @@
+package javassist;
+
+import javassist.convert.TransformCallExceptSuperCallToStatic;
+
+public class EnhancedCodeConverter extends CodeConverter {
+
+    public void redirectMethodCallExceptSuperCallToStatic(CtMethod origMethod, CtMethod substMethod) throws CannotCompileException {
+        transformers = new TransformCallExceptSuperCallToStatic(transformers, origMethod,
+                substMethod);
+    }
+}

--- a/projects/sdk/core/transform-kit/src/main/java/javassist/convert/TransformCallExceptSuperCallToStatic.java
+++ b/projects/sdk/core/transform-kit/src/main/java/javassist/convert/TransformCallExceptSuperCallToStatic.java
@@ -1,0 +1,55 @@
+package javassist.convert;
+
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.CtMethod;
+import javassist.NotFoundException;
+import javassist.bytecode.BadBytecode;
+import javassist.bytecode.CodeIterator;
+import javassist.bytecode.ConstPool;
+
+public class TransformCallExceptSuperCallToStatic extends TransformCallToStatic {
+    public TransformCallExceptSuperCallToStatic(Transformer next, CtMethod origMethod, CtMethod substMethod) {
+        super(next, origMethod, substMethod);
+    }
+
+    // COPY FROM TransformCall
+    @Override
+    public int transform(CtClass clazz, int pos, CodeIterator iterator, ConstPool cp) throws BadBytecode {
+        int c = iterator.byteAt(pos);
+        if (c == INVOKEINTERFACE || c == INVOKESTATIC || c == INVOKEVIRTUAL) { // THE ONLY DIFFERENCE WITH TransformCall
+            int index = iterator.u16bitAt(pos + 1);
+            String cname = cp.eqMember(methodname, methodDescriptor, index);
+            if (cname != null && matchClass(cname, clazz.getClassPool())) {
+                int ntinfo = cp.getMemberNameAndType(index);
+                pos = match(c, pos, iterator,
+                        cp.getNameAndTypeDescriptor(ntinfo), cp);
+            }
+        }
+
+        return pos;
+    }
+
+    // COPY FROM TransformCall
+    private boolean matchClass(String name, ClassPool pool) {
+        if (classname.equals(name))
+            return true;
+
+        try {
+            CtClass clazz = pool.get(name);
+            CtClass declClazz = pool.get(classname);
+            if (clazz.subtypeOf(declClazz))
+                try {
+                    CtMethod m = clazz.getMethod(methodname, methodDescriptor);
+                    return m.getDeclaringClass().getName().equals(classname);
+                } catch (NotFoundException e) {
+                    // maybe the original method has been removed.
+                    return true;
+                }
+        } catch (NotFoundException e) {
+            return false;
+        }
+
+        return false;
+    }
+}

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/FragmentSupportTransform.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/specific/FragmentSupportTransform.kt
@@ -104,12 +104,15 @@ class FragmentSupportTransform : SpecificTransform() {
 
             override fun transform(ctClass: CtClass) {
                 ctClass.defrost()
-                val codeConverter = CodeConverter()
+                val codeConverter = EnhancedCodeConverter()
                 codeConverter.redirectMethodCallToStatic(
                     getActivityMethod,
                     fragmentGetActivityMethod
                 )
-                codeConverter.redirectMethodCallToStatic(getContextMethod, fragmentGetContextMethod)
+                codeConverter.redirectMethodCallExceptSuperCallToStatic(
+                    getContextMethod,
+                    fragmentGetContextMethod
+                )
                 codeConverter.redirectMethodCallToStatic(getHostMethod, fragmentGetHostMethod)
                 codeConverter.redirectMethodCallToStatic(
                     startActivityMethod1,

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/fragment/TestNormalFragment.java
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/fragment/TestNormalFragment.java
@@ -91,4 +91,12 @@ public class TestNormalFragment extends Fragment implements TestFragment {
         super.onInflate(activity, attrs, savedInstanceState);
         commonLogic.onInflate(activity, attrs, savedInstanceState);
     }
+
+    /**
+     * 测试Fragment override getContext的场景
+     */
+    @Override
+    public Context getContext() {
+        return super.getContext();
+    }
 }


### PR DESCRIPTION
redirectMethodCallToStatic方法复用了TransformCall的匹配逻辑，
即`if (c == INVOKEINTERFACE || c == INVOKESPECIAL || c == INVOKESTATIC || c == INVOKEVIRTUAL)`
其中INVOKESPECIAL即包含super调用。而我们在替换fragmentGetContext方法时，并不需要对super调用进行转换。
如果转换会导致fragmentGetContext静态方法中对fragment的getContext调用循环回自身。

因此对这种情况忽略INVOKESPECIAL调用，添加新方法redirectMethodCallExceptSuperCallToStatic。

fix #647