### PR TITLE
fix(core): 插件Activity在getSystemService时默认委托给宿主Activity

### DIFF
--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginActivity.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginActivity.java
@@ -109,4 +109,13 @@ public abstract class PluginActivity extends GeneratedPluginActivity {
         hostActivityDelegator.setTheme(resid);
     }
 
+    @Override
+    public Object getSystemService(String name) {
+        if (LAYOUT_INFLATER_SERVICE.equals(name)) {
+            return super.getSystemService(name);
+        } else {
+            return hostActivityDelegator.getHostActivity().getImplementActivity()
+                    .getSystemService(name);
+        }
+    }
 }

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/dialog/TestDialogActivity.java
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/dialog/TestDialogActivity.java
@@ -18,7 +18,10 @@
 
 package com.tencent.shadow.test.plugin.general_cases.lib.usecases.dialog;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Context;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.ViewGroup;
 
@@ -47,5 +50,13 @@ public class TestDialogActivity extends Activity {
         );
 
         dialog.show();
+    }
+
+    @SuppressLint("NewApi")
+    @Override
+    protected void attachBaseContext(Context newBase) {
+        Configuration configuration = new Configuration();
+        Context context = newBase.createConfigurationContext(configuration);
+        super.attachBaseContext(context);
     }
 }


### PR DESCRIPTION
而不是像ShadowContext一样默认委托给baseContext。

baseContext可能不是一个Activity，导致Dialog等代码在
getSystemService(Context.WINDOW_SERVICE)时，
得到的WindowManager缺少mParentWindow。进而在
WindowManagerGlobal#addView时，依赖
mParentWindow.adjustLayoutParamsForSubWindow初始化
WindowManager.LayoutParams的token时失败。
从而导致Dialog.show会抛出"token is null"异常。

fix #640