### PR TITLE
test: 修复API 29以上虚拟机自动化测试

### DIFF
--- a/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/SubDirContextThemeWrapperTest.java
+++ b/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/SubDirContextThemeWrapperTest.java
@@ -18,6 +18,10 @@
 
 package com.tencent.shadow.test.cases.plugin_main;
 
+import static android.content.Context.MODE_PRIVATE;
+import static android.os.Environment.DIRECTORY_MUSIC;
+import static android.os.Environment.DIRECTORY_PODCASTS;
+
 import android.content.SharedPreferences;
 import android.os.Build;
 
@@ -29,10 +33,6 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.Arrays;
-
-import static android.content.Context.MODE_PRIVATE;
-import static android.os.Environment.DIRECTORY_MUSIC;
-import static android.os.Environment.DIRECTORY_PODCASTS;
 
 abstract class SubDirContextThemeWrapperTest extends PluginMainAppTest {
 
@@ -324,9 +324,9 @@ abstract class SubDirContextThemeWrapperTest extends PluginMainAppTest {
     @Test
     public void testDatabaseList() {
         String dbName = EXPECT_NAME + "_bar";
-        matchTextWithViewTag(
+        matchSubstringWithViewTag(
                 "TAG_DATABASE_LIST",
-                "[" + dbName + "]"
+                dbName
         );
     }
 

--- a/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/gallery/TestApplication.java
+++ b/projects/test/plugin/general-cases/general-cases-lib/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/gallery/TestApplication.java
@@ -77,8 +77,12 @@ class TestActivityLifecycleCallbacks implements Application.ActivityLifecycleCal
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            TestActivityLifecycleCallbacks testForRegisterInPreCreatedCallback = new TestActivityLifecycleCallbacks("TestForRegisterInPreCreatedCallback");
             TestApplication.getInstance().registerActivityLifecycleCallbacks(
-                    new TestActivityLifecycleCallbacks("TestForRegisterInPreCreatedCallback")
+                    testForRegisterInPreCreatedCallback
+            );
+            TestApplication.getInstance().unregisterActivityLifecycleCallbacks(
+                    testForRegisterInPreCreatedCallback
             );
         }
     }


### PR DESCRIPTION
1. onActivityPreCreated回调中注册回调，不断启动Activity后无限放大回调数量，OOM。
2. DatabaseList在新版本上内容有增加，改为只匹配部分字符串。