### PR TITLE
ci: 修复CI上Gradle Wrapper还原失败的问题

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -27,14 +27,16 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: revert gradle wrapper mirror setting
+        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
       - name: buildSdk
-        run: ./gradlew wrapper; ./gradlew buildSdk -S
+        run: ./gradlew buildSdk -S
       - name: lintSdk
-        run: ./gradlew wrapper; ./gradlew lintSdk
+        run: ./gradlew lintSdk
       - name: build sample/source
-        run: ./gradlew wrapper; ./gradlew build
+        run: ./gradlew build
       - name: unit test
-        run: ./gradlew wrapper; ./gradlew jvmTestSdk -S
+        run: ./gradlew jvmTestSdk -S
       - name: run androidTestSdk on API 28 emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -43,7 +45,7 @@ jobs:
           target: default
           arch: x86_64
           profile: pixel_xl
-          script: ./gradlew wrapper; ./gradlew androidTestSdk
+          script: ./gradlew androidTestSdk
       - name: stop gradle deamon for actions/cache
         run: ./gradlew --stop
   build-on-windows:
@@ -68,12 +70,14 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: revert gradle wrapper mirror setting
+        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
       - name: buildSdk
-        run: ./gradlew wrapper; ./gradlew buildSdk -S
+        run: ./gradlew buildSdk -S
       - name: lintSdk
-        run: ./gradlew wrapper; ./gradlew lintSdk
+        run: ./gradlew lintSdk
       - name: build sample/source
-        run: ./gradlew wrapper; ./gradlew build
+        run: ./gradlew build
       - name: stop gradle deamon for actions/cache
         run: ./gradlew --stop
   build-samples:
@@ -93,14 +97,16 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: revert gradle wrapper mirror setting
+        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
       - name: build sample/maven/host-project
         working-directory: projects/sample/maven/host-project
-        run: ./gradlew wrapper; ./gradlew assemble
+        run: ./gradlew assemble
       - name: build sample/maven/manager-project
         working-directory: projects/sample/maven/manager-project
-        run: ./gradlew wrapper; ./gradlew assemble
+        run: ./gradlew assemble
       - name: build sample/maven/plugin-project
         working-directory: projects/sample/maven/plugin-project
-        run: ./gradlew wrapper; ./gradlew assemble
+        run: ./gradlew assemble
       - name: stop gradle deamon for actions/cache
         run: ./gradlew --stop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,16 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: revert gradle wrapper mirror setting
+        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
       - name: buildSdk
-        run: ./gradlew wrapper; ./gradlew buildSdk
+        run: ./gradlew buildSdk
       - name: lintSdk
-        run: ./gradlew wrapper; ./gradlew lintSdk
+        run: ./gradlew lintSdk
       - name: build sample/source
-        run: ./gradlew wrapper; ./gradlew build
+        run: ./gradlew build
       - name: unit test
-        run: ./gradlew wrapper; ./gradlew jvmTestSdk -S
+        run: ./gradlew jvmTestSdk -S
       - name: run androidTestSdk on API 28 emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -44,7 +46,7 @@ jobs:
           target: default
           arch: x86_64
           profile: pixel_xl
-          script: ./gradlew wrapper; ./gradlew androidTestSdk
+          script: ./gradlew androidTestSdk
       - name: stop gradle deamon for actions/cache
         run: ./gradlew --stop
   publish:
@@ -72,7 +74,9 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: revert gradle wrapper mirror setting
+        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
       - name: publish
-        run: ./gradlew wrapper; ./gradlew publish
+        run: ./gradlew publish
       - name: stop gradle deamon for actions/cache
         run: ./gradlew --stop


### PR DESCRIPTION
Gradle升级到7.0.2之后，Wrapper还原url的逻辑有变化。