### PR TITLE
feat(core.manager): 固定getAbi实现

### DIFF
--- a/projects/sample/maven/manager-project/sample-manager/src/main/java/com/tencent/shadow/sample/manager/SamplePluginManager.java
+++ b/projects/sample/maven/manager-project/sample-manager/src/main/java/com/tencent/shadow/sample/manager/SamplePluginManager.java
@@ -37,14 +37,6 @@ public class SamplePluginManager extends FastPluginManager {
     }
 
     /**
-     * @return demo插件so的abi
-     */
-    @Override
-    public String getAbi() {
-        return "";
-    }
-
-    /**
      * @return 宿主中注册的PluginProcessService实现的类名
      */
     @Override

--- a/projects/sample/source/sample-manager/src/main/java/com/tencent/shadow/sample/manager/SamplePluginManager.java
+++ b/projects/sample/source/sample-manager/src/main/java/com/tencent/shadow/sample/manager/SamplePluginManager.java
@@ -56,14 +56,6 @@ public class SamplePluginManager extends FastPluginManager {
     }
 
     /**
-     * @return 宿主so的ABI。插件必须和宿主使用相同的ABI。
-     */
-    @Override
-    public String getAbi() {
-        return "";
-    }
-
-    /**
      * @return 宿主中注册的PluginProcessService实现的类名
      */
     @Override

--- a/projects/test/dynamic/manager/test-dynamic-manager/src/main/java/com/tencent/shadow/test/dynamic/manager/ActivityTestDynamicPluginManager.java
+++ b/projects/test/dynamic/manager/test-dynamic-manager/src/main/java/com/tencent/shadow/test/dynamic/manager/ActivityTestDynamicPluginManager.java
@@ -53,14 +53,6 @@ public class ActivityTestDynamicPluginManager extends FastPluginManager {
     }
 
     /**
-     * @return 宿主so的ABI。插件必须和宿主使用相同的ABI。
-     */
-    @Override
-    public String getAbi() {
-        return "";
-    }
-
-    /**
      * @return 宿主中注册的PluginProcessService实现的类名
      */
     @Override

--- a/projects/test/dynamic/manager/test-dynamic-manager/src/main/java/com/tencent/shadow/test/dynamic/manager/ServiceTestDynamicPluginManager.java
+++ b/projects/test/dynamic/manager/test-dynamic-manager/src/main/java/com/tencent/shadow/test/dynamic/manager/ServiceTestDynamicPluginManager.java
@@ -56,14 +56,6 @@ public class ServiceTestDynamicPluginManager extends FastPluginManager {
     }
 
     /**
-     * @return 宿主so的ABI。插件必须和宿主使用相同的ABI。
-     */
-    @Override
-    public String getAbi() {
-        return "";
-    }
-
-    /**
      * @return 宿主中注册的PluginProcessService实现的类名
      */
     @Override


### PR DESCRIPTION
可以从宿主的`ApplicationInfo.nativeLibraryDir`获得宿主安装时系统为它自动确定的ABI。
插件只能使用这个ABI，所以getAbi实现可以固定下来。

close #684
