### PR TITLE
test: 修复拆分source sample后插件使用宿主类测试找不到类的问题

### DIFF
--- a/projects/sample/source/sample-plugin/sample-app/build.gradle
+++ b/projects/sample/source/sample-plugin/sample-app/build.gradle
@@ -130,6 +130,7 @@ shadow {
                         buildTask = ':sample-base:assemblePluginDebug'
                         apkName = 'sample-base-plugin-debug.apk'
                         apkPath = 'projects/sample/source/sample-plugin/sample-base/build/outputs/apk/plugin/debug/sample-base-plugin-debug.apk'
+                        hostWhiteList = ["com.tencent.shadow.sample.host.lib"]
                     }
                 }
             }
@@ -162,6 +163,7 @@ shadow {
                         buildTask = ':sample-base:assemblePluginRelease'
                         apkName = 'sample-base-plugin-release.apk'
                         apkPath = 'projects/sample/source/sample-plugin/sample-base/build/outputs/apk/plugin/release/sample-base-plugin-release.apk'
+                        hostWhiteList = ["com.tencent.shadow.sample.host.lib"]
                     }
                 }
             }


### PR DESCRIPTION
拆分后sample-app的parent是sample-base了，
由于hostWhiteList是设置在PluginClassLoader上的，
所以需要在sample-base的hostWhiteList上设置白名单，
才能使sample-app可以访问宿主中的类。

fixup! 08da57dd
fix #692