### PR TITLE
test: 在sample演示一种宿主加载插件View的方法

### DIFF
--- a/projects/sample/source/sample-constant/src/main/java/com/tencent/shadow/sample/constant/Constant.java
+++ b/projects/sample/source/sample-constant/src/main/java/com/tencent/shadow/sample/constant/Constant.java
@@ -30,4 +30,5 @@ final public class Constant {
     public static final int FROM_ID_NOOP = 1000;
     public static final int FROM_ID_START_ACTIVITY = 1002;
     public static final int FROM_ID_CLOSE = 1003;
+    public static final int FROM_ID_LOAD_VIEW_TO_HOST = 1004;
 }

--- a/projects/sample/source/sample-host-lib/src/main/java/com/tencent/shadow/sample/host/lib/HostAddPluginViewContainer.java
+++ b/projects/sample/source/sample-host-lib/src/main/java/com/tencent/shadow/sample/host/lib/HostAddPluginViewContainer.java
@@ -1,0 +1,7 @@
+package com.tencent.shadow.sample.host.lib;
+
+import android.view.View;
+
+public interface HostAddPluginViewContainer {
+    void addView(View view);
+}

--- a/projects/sample/source/sample-host-lib/src/main/java/com/tencent/shadow/sample/host/lib/HostAddPluginViewContainerHolder.java
+++ b/projects/sample/source/sample-host-lib/src/main/java/com/tencent/shadow/sample/host/lib/HostAddPluginViewContainerHolder.java
@@ -1,0 +1,8 @@
+package com.tencent.shadow.sample.host.lib;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HostAddPluginViewContainerHolder {
+    public final static Map<Integer, HostAddPluginViewContainer> instances = new HashMap<>();
+}

--- a/projects/sample/source/sample-host/src/main/AndroidManifest.xml
+++ b/projects/sample/source/sample-host/src/main/AndroidManifest.xml
@@ -75,23 +75,26 @@
         android:theme="@android:style/Theme.DeviceDefault"
         android:usesCleartextTraffic="true"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name="com.tencent.shadow.sample.host.MainActivity"
-            >
+        <activity android:name="com.tencent.shadow.sample.host.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".plugin_view.HostAddPluginViewActivity"
+            android:process=":plugin" />
+
         <provider
             android:authorities="${applicationId}.contentprovider.authority.dynamic"
             android:name="com.tencent.shadow.core.runtime.container.PluginContainerContentProvider"
             android:grantUriPermissions="true"
-            android:process=":plugin"
-            />
-        <service android:name="com.tencent.shadow.sample.host.PluginProcessPPS"
-            android:process=":plugin"
-            />
+            android:process=":plugin" />
+
+        <service
+            android:name="com.tencent.shadow.sample.host.PluginProcessPPS"
+            android:process=":plugin" />
         <service
             android:name="com.tencent.shadow.sample.host.Plugin2ProcessPPS"
             android:process=":plugin2" />
@@ -136,6 +139,11 @@
 
             />
         <!--dynamic activity注册 end -->
+        <receiver android:name=".plugin_view.MainProcessManagerReceiver">
+            <intent-filter>
+                <action android:name="sample_host.manager.startPluginService" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/projects/sample/source/sample-host/src/main/java/com/tencent/shadow/sample/host/MainActivity.java
+++ b/projects/sample/source/sample-host/src/main/java/com/tencent/shadow/sample/host/MainActivity.java
@@ -34,6 +34,7 @@ import android.widget.Spinner;
 import android.widget.TextView;
 
 import com.tencent.shadow.sample.constant.Constant;
+import com.tencent.shadow.sample.host.plugin_view.HostAddPluginViewActivity;
 
 
 public class MainActivity extends Activity {
@@ -90,6 +91,14 @@ public class MainActivity extends Activity {
             }
         });
         rootView.addView(startPluginButton);
+
+        Button startHostAddPluginViewActivityButton = new Button(this);
+        startHostAddPluginViewActivityButton.setText("宿主添加插件View");
+        startHostAddPluginViewActivityButton.setOnClickListener(v -> {
+            Intent intent = new Intent(this, HostAddPluginViewActivity.class);
+            startActivity(intent);
+        });
+        rootView.addView(startHostAddPluginViewActivityButton);
 
         setContentView(rootView);
 

--- a/projects/sample/source/sample-host/src/main/java/com/tencent/shadow/sample/host/plugin_view/HostAddPluginViewActivity.java
+++ b/projects/sample/source/sample-host/src/main/java/com/tencent/shadow/sample/host/plugin_view/HostAddPluginViewActivity.java
@@ -1,0 +1,74 @@
+package com.tencent.shadow.sample.host.plugin_view;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.tencent.shadow.sample.host.lib.HostAddPluginViewContainer;
+import com.tencent.shadow.sample.host.lib.HostAddPluginViewContainerHolder;
+
+public class HostAddPluginViewActivity extends Activity implements HostAddPluginViewContainer {
+    private ViewGroup mPluginViewContainer;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        LinearLayout activityContentView = new LinearLayout(this);
+        activityContentView.setOrientation(LinearLayout.VERTICAL);
+
+        LinearLayout.LayoutParams wrapContent = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+
+        TextView note = new TextView(this);
+        note.setLayoutParams(wrapContent);
+        note.setText("需要先启动插件sample-plugin-app后，才能点下面的加载插件View");
+
+        Button loadButton = new Button(this);
+        loadButton.setText("加载插件View");
+        loadButton.setOnClickListener(this::loadPluginView);
+        loadButton.setLayoutParams(wrapContent);
+
+        ViewGroup pluginViewContainer = new LinearLayout(this);
+        pluginViewContainer.setLayoutParams(wrapContent);
+        mPluginViewContainer = pluginViewContainer;
+
+        View[] views = {
+                note,
+                loadButton,
+                pluginViewContainer
+        };
+        for (View view : views) {
+            activityContentView.addView(view);
+        }
+        setContentView(activityContentView);
+    }
+
+    private void loadPluginView(View view) {
+        //简化逻辑，只允许点一次
+        view.setEnabled(false);
+
+        //因为当前Activity和插件都在:plugin进程，不能直接操作主进程的manager对象，所以通过一个广播调用manager。
+        Intent intent = new Intent();
+        intent.setPackage(getPackageName());
+        intent.setAction("sample_host.manager.startPluginService");
+
+        final int id = System.identityHashCode(this);
+        HostAddPluginViewContainerHolder.instances.put(id, this);
+        intent.putExtra("id", id);
+
+        sendBroadcast(intent);
+    }
+
+    @Override
+    public void addView(View view) {
+        mPluginViewContainer.addView(view);
+    }
+}

--- a/projects/sample/source/sample-host/src/main/java/com/tencent/shadow/sample/host/plugin_view/MainProcessManagerReceiver.java
+++ b/projects/sample/source/sample-host/src/main/java/com/tencent/shadow/sample/host/plugin_view/MainProcessManagerReceiver.java
@@ -1,0 +1,16 @@
+package com.tencent.shadow.sample.host.plugin_view;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import com.tencent.shadow.sample.constant.Constant;
+import com.tencent.shadow.sample.host.HostApplication;
+
+public class MainProcessManagerReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        HostApplication.getApp().getPluginManager()
+                .enter(context, Constant.FROM_ID_LOAD_VIEW_TO_HOST, intent.getExtras(), null);
+    }
+}

--- a/projects/sample/source/sample-manager/src/main/java/com/tencent/shadow/sample/manager/SamplePluginManager.java
+++ b/projects/sample/source/sample-manager/src/main/java/com/tencent/shadow/sample/manager/SamplePluginManager.java
@@ -25,6 +25,7 @@ import static com.tencent.shadow.sample.constant.Constant.PART_KEY_PLUGIN_MAIN_A
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.RemoteException;
 import android.view.LayoutInflater;
 import android.view.View;
 
@@ -80,8 +81,24 @@ public class SamplePluginManager extends FastPluginManager {
             onStartActivity(context, bundle, callback);
         } else if (fromId == Constant.FROM_ID_CLOSE) {
             close();
+        } else if (fromId == Constant.FROM_ID_LOAD_VIEW_TO_HOST) {
+            loadViewToHost(context, bundle);
         } else {
             throw new IllegalArgumentException("不认识的fromId==" + fromId);
+        }
+    }
+
+    private void loadViewToHost(final Context context, Bundle bundle) {
+        Intent pluginIntent = new Intent();
+        pluginIntent.setClassName(
+                context.getPackageName(),
+                "com.tencent.shadow.sample.plugin.app.lib.usecases.service.HostAddPluginViewService"
+        );
+        pluginIntent.putExtras(bundle);
+        try {
+            mPluginLoader.startPluginService(pluginIntent);
+        } catch (RemoteException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/projects/sample/source/sample-plugin/sample-app/src/main/AndroidManifest.xml
+++ b/projects/sample/source/sample-plugin/sample-app/src/main/AndroidManifest.xml
@@ -67,6 +67,7 @@
             android:authorities="${applicationId}.provider.test"
             android:name="com.tencent.shadow.sample.plugin.app.lib.usecases.provider.TestProvider" />
 
+        <service android:name=".usecases.service.HostAddPluginViewService" />
     </application>
 
 </manifest>

--- a/projects/sample/source/sample-plugin/sample-app/src/main/java/com/tencent/shadow/sample/plugin/app/lib/usecases/service/HostAddPluginViewService.java
+++ b/projects/sample/source/sample-plugin/sample-app/src/main/java/com/tencent/shadow/sample/plugin/app/lib/usecases/service/HostAddPluginViewService.java
@@ -1,0 +1,34 @@
+package com.tencent.shadow.sample.plugin.app.lib.usecases.service;
+
+import android.app.IntentService;
+import android.content.Intent;
+import android.os.Handler;
+import android.os.Looper;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+
+import com.tencent.shadow.sample.host.lib.HostAddPluginViewContainer;
+import com.tencent.shadow.sample.host.lib.HostAddPluginViewContainerHolder;
+import com.tencent.shadow.sample.plugin.app.lib.R;
+
+public class HostAddPluginViewService extends IntentService {
+    private final Handler uiHandler = new Handler(Looper.getMainLooper());
+
+    public HostAddPluginViewService() {
+        super("HostAddPluginViewService");
+    }
+
+    @Override
+    protected void onHandleIntent(@Nullable Intent intent) {
+        int id = intent.getIntExtra("id", 0);
+        HostAddPluginViewContainer viewContainer
+                = HostAddPluginViewContainerHolder.instances.remove(id);
+
+        uiHandler.post(() -> {
+            View view = LayoutInflater.from(this).inflate(
+                    R.layout.layout_host_add_plugin_view, null, false);
+            viewContainer.addView(view);
+        });
+    }
+}

--- a/projects/sample/source/sample-plugin/sample-app/src/main/res/layout/layout_host_add_plugin_view.xml
+++ b/projects/sample/source/sample-plugin/sample-app/src/main/res/layout/layout_host_add_plugin_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/host_add_plugin_view" />
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/collapse" />
+</LinearLayout>

--- a/projects/sample/source/sample-plugin/sample-app/src/main/res/values/strings.xml
+++ b/projects/sample/source/sample-plugin/sample-app/src/main/res/values/strings.xml
@@ -19,5 +19,6 @@
 <resources>
     <!-- Simple strings. -->
     <string name="app_name">Shadow主测试用例集合</string>
+    <string name="host_add_plugin_view">这是插件中的string资源</string>
 </resources>
 


### PR DESCRIPTION
宿主在插件进程的HostAddPluginViewActivity调用宿主在主进程的MainProcessManagerReceiver。
主进程的MainProcessManagerReceiver调用主进程的manager对象。
主进程的manager对象调用PluginLoader接口的startPluginService方法。
插件中的HostAddPluginViewService通过共享宿主中的类HostAddPluginViewContainerHolder获取
宿主中同进程的HostAddPluginViewActivity对象，将自己构造的View设置到其中。

插件View由插件代码构造，此时View对象只能直接被同进程的宿主代码复用。
所以宿主中的HostAddPluginViewActivity要设置在插件进程。

由于Intent不能直接传递对象，所以通过HostAddPluginViewContainerHolder传递HostAddPluginViewActivity对象
到插件代码中，插件代码以HostAddPluginViewContainer接口操作该对象。

由于HostAddPluginViewActivity位于插件进程，而插件是由主进程中的manager对象
启动的，所以通过一个MainProcessManagerReceiver在主进程转调manager对象。

需要注意这并不是唯一的实现方案。方案的关键在于View构造时有自己的Context，构造后可以将对象添加到任意ViewGroup中。

#702