### PR TITLE
fix(core.transform-kit): 忽略根目录的module-info.class

### DIFF
--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransform.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransform.kt
@@ -83,9 +83,12 @@ abstract class AbstractTransform(
 
     private fun CtClass.debugWriteJar(outputEntryName: String?, outputStream: ZipOutputStream) {
         //忽略META-INF
-        if (outputEntryName?.startsWith("META-INF/") == true) {
-            return
-        }
+        if (outputEntryName != null
+            && listOf<(String) -> Boolean>(
+                { it.startsWith("META-INF/") },
+                { it == "module-info.class" },
+            ).any { it(outputEntryName) }
+        ) return
 
         try {
             val entryName = outputEntryName ?: (name.replace('.', '/') + ".class")


### PR DESCRIPTION
有些第三方库的module-info.class没有放到`META-INF/`目录下。

fix #704