### PR TITLE
feat(core.gradle-plugin): 对kotlin-android插件应用顺序要求作出提示

### DIFF
--- a/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/ShadowPlugin.kt
+++ b/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/ShadowPlugin.kt
@@ -71,6 +71,19 @@ class ShadowPlugin : Plugin<Project> {
 
             createGeneratePluginManifestTasks(project)
         }
+
+        checkKotlinAndroidPluginForPluginManifestTask(project)
+    }
+
+    /**
+     * GeneratePluginManifestTask会向android DSL添加新的java源码目录，
+     * 而kotlin-android会在syncKotlinAndAndroidSourceSets中接管java的源码目录，
+     * 从而使后添加到android DSL中的java目录失效。
+     */
+    private fun checkKotlinAndroidPluginForPluginManifestTask(project: Project) {
+        if (project.plugins.hasPlugin("kotlin-android")) {
+            throw Error("必须在kotlin-android之前应用com.tencent.shadow.plugin")
+        }
     }
 
     private fun createPackagePluginTasks(project: Project) {


### PR DESCRIPTION
为了不依赖kotlin-android lib，就不针对这种情况自动兼容了。

fix #745