### PR TITLE
添加getIdentify，利用宿主与插件id查找资源

### DIFF
--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/MixResources.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/MixResources.java
@@ -281,4 +281,13 @@ public class MixResources extends ResourcesWrapper {
             return mHostResources.openRawResourceFd(id);
         }
     }
+
+    @Override
+    public int getIdentifier(String name, String defType, String defPackage) {
+        try {
+            return super.getIdentifier(name, defType, defPackage);
+        } catch (NotFoundException e) {
+            return mHostResources.getIdentifier(name, defType, defPackage);
+        }
+    }
 }


### PR DESCRIPTION
MixResources有时候需要获取插件的resource目录下的id索引