### PR TITLE
feat(core.manager): API 26以上跳过odex相关逻辑

### DIFF
--- a/projects/sdk/core/manager/src/main/java/com/tencent/shadow/core/manager/BasePluginManager.java
+++ b/projects/sdk/core/manager/src/main/java/com/tencent/shadow/core/manager/BasePluginManager.java
@@ -133,7 +133,8 @@ public abstract class BasePluginManager {
     public final void onInstallCompleted(PluginConfig pluginConfig,
                                          Map<String, String> soDirMap) {
         File root = mUnpackManager.getAppDir();
-        String oDexDir = AppCacheFolderManager.getODexDir(root, pluginConfig.UUID).getAbsolutePath();
+        String oDexDir = ODexBloc.isEffective() ?
+                AppCacheFolderManager.getODexDir(root, pluginConfig.UUID).getAbsolutePath() : null;
 
         mInstalledDao.insert(pluginConfig, soDirMap, oDexDir);
     }
@@ -178,6 +179,10 @@ public abstract class BasePluginManager {
      * @param partKey 要oDex的插件partkey
      */
     public final void oDexPlugin(String uuid, String partKey, File apkFile) throws InstallPluginException {
+        if (!ODexBloc.isEffective()) {
+            return;
+        }
+
         try {
             File root = mUnpackManager.getAppDir();
             File oDexDir = AppCacheFolderManager.getODexDir(root, uuid);
@@ -199,6 +204,10 @@ public abstract class BasePluginManager {
      * @param apkFile 插件apk文件
      */
     public final void oDexPluginLoaderOrRunTime(String uuid, int type, File apkFile) throws InstallPluginException {
+        if (!ODexBloc.isEffective()) {
+            return;
+        }
+
         try {
             File root = mUnpackManager.getAppDir();
             File oDexDir = AppCacheFolderManager.getODexDir(root, uuid);

--- a/projects/sdk/core/manager/src/main/java/com/tencent/shadow/core/manager/installplugin/ODexBloc.java
+++ b/projects/sdk/core/manager/src/main/java/com/tencent/shadow/core/manager/installplugin/ODexBloc.java
@@ -18,6 +18,8 @@
 
 package com.tencent.shadow.core.manager.installplugin;
 
+import android.os.Build;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,7 +30,20 @@ public class ODexBloc {
 
     private static ConcurrentHashMap<String, Object> sLocks = new ConcurrentHashMap<>();
 
+    /**
+     * DexClassLoader的optimizedDirectory参数从API 26起就无效了
+     * 此方法统一判断这一特性是否生效
+     *
+     * @return <code>true</code>表示ODexBloc还有作用
+     */
+    public static boolean isEffective() {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.O;
+    }
+
     public static void oDexPlugin(File apkFile, File oDexDir, File copiedTagFile) throws InstallPluginException {
+        if (!isEffective()) {
+            return;
+        }
 
         String key = apkFile.getAbsolutePath();
         Object lock = sLocks.get(key);


### PR DESCRIPTION
DexClassLoader的optimizedDirectory参数从API 26起就无效了