### PR TITLE
test: test-none-dynamic-host配置插件访问宿主的白名单

### DIFF
--- a/projects/test/none-dynamic/host/test-none-dynamic-host/build.gradle
+++ b/projects/test/none-dynamic/host/test-none-dynamic-host/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation 'com.tencent.shadow.core:loader'
     implementation 'com.tencent.shadow.core:activity-container'
     implementation project(':custom-view')
+    implementation 'androidx.test.espresso:espresso-idling-resource:3.3.0'
 }
 
 def createCopyTask(projectName, buildType, name, apkName) {

--- a/projects/test/none-dynamic/host/test-none-dynamic-host/src/main/java/com/tencent/shadow/test/none_dynamic/host/HostApplication.java
+++ b/projects/test/none-dynamic/host/test-none-dynamic-host/src/main/java/com/tencent/shadow/test/none_dynamic/host/HostApplication.java
@@ -28,16 +28,13 @@ import com.tencent.shadow.core.common.InstalledApk;
 import com.tencent.shadow.core.common.LoggerFactory;
 import com.tencent.shadow.core.load_parameters.LoadParameters;
 import com.tencent.shadow.core.loader.ShadowPluginLoader;
-import com.tencent.shadow.core.loader.exceptions.LoadPluginException;
 import com.tencent.shadow.core.runtime.container.ContentProviderDelegateProviderHolder;
 import com.tencent.shadow.core.runtime.container.DelegateProviderHolder;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class HostApplication extends Application {
     private static Application sApp;
@@ -66,7 +63,15 @@ public class HostApplication extends Application {
         }
 
         if (mPluginLoader.getPluginParts(partKey) == null) {
-            LoadParameters loadParameters = new LoadParameters(null, partKey, null, null);
+            // 插件访问宿主类的白名单
+            String[] hostWhiteList = new String[]{
+                    "androidx.test.espresso",//这个包添加是为了general-cases插件中可以访问测试框架的类
+                    "com.tencent.shadow.test.lib.plugin_use_host_code_lib.interfaces"//测试插件访问宿主白名单类
+            };
+            LoadParameters loadParameters = new LoadParameters(null,
+                    partKey,
+                    null,
+                    hostWhiteList);
 
             Parcel parcel = Parcel.obtain();
             loadParameters.writeToParcel(parcel, 0);


### PR DESCRIPTION
修复部分依赖espresso-idling-resource的测试用例会Crash的问题。

fix #780