### PR TITLE
fix(core.manager): API 26保留odex过程

### DIFF
--- a/projects/sdk/core/manager/src/main/java/com/tencent/shadow/core/manager/installplugin/ODexBloc.java
+++ b/projects/sdk/core/manager/src/main/java/com/tencent/shadow/core/manager/installplugin/ODexBloc.java
@@ -31,13 +31,13 @@ public class ODexBloc {
     private static ConcurrentHashMap<String, Object> sLocks = new ConcurrentHashMap<>();
 
     /**
-     * DexClassLoader的optimizedDirectory参数从API 26起就无效了
+     * DexClassLoader的optimizedDirectory参数从API 27起就无效了
      * 此方法统一判断这一特性是否生效
      *
      * @return <code>true</code>表示ODexBloc还有作用
      */
     public static boolean isEffective() {
-        return Build.VERSION.SDK_INT < Build.VERSION_CODES.O;
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.O_MR1;
     }
 
     public static void oDexPlugin(File apkFile, File oDexDir, File copiedTagFile) throws InstallPluginException {


### PR DESCRIPTION
从AOSP源码和API 26虚拟机测试来看，DexClassLoader中new File的逻辑是API 27才去掉的。API 26的odex实际可能不生效。

fix #828