### PR TITLE
feat(core.loader): 从宿主复制PackageInfo.permission到插件

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/managers/PluginPackageManagerImpl.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/managers/PluginPackageManagerImpl.kt
@@ -38,16 +38,19 @@ internal class PluginPackageManagerImpl(
             hostPackageManager.getApplicationInfo(packageName, flags)
         }
 
-    override fun getPackageInfo(packageName: String, flags: Int): PackageInfo? =
-        if (packageName.isPlugin()) {
+    override fun getPackageInfo(packageName: String, flags: Int): PackageInfo? {
+        val hostPackageInfo = hostPackageManager.getPackageInfo(packageName, flags)
+        return if (packageName.isPlugin()) {
             val packageInfo = hostPackageManager.getPackageArchiveInfo(pluginArchiveFilePath, flags)
             if (packageInfo != null) {
                 packageInfo.applicationInfo = getPluginApplicationInfo(flags)
+                packageInfo.permissions = hostPackageInfo.permissions
             }
             packageInfo
         } else {
-            hostPackageManager.getPackageInfo(packageName, flags)
+            hostPackageInfo
         }
+    }
 
     override fun getActivityInfo(component: ComponentName, flags: Int): ActivityInfo? =
         getComponentInfo(


### PR DESCRIPTION
不返回插件Manifest中注册的权限，因为它们也不会生效。

close #824