### PR TITLE
feat(core): 支持插件ProviderInfo读取grantUriPermissions字段

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/managers/PluginContentProviderManager.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/managers/PluginContentProviderManager.kt
@@ -103,8 +103,7 @@ class PluginContentProviderManager() : UriConverter.UriParseDelegate {
                 providerInfo.packageName = context.packageName
                 providerInfo.name = it.className
                 providerInfo.authority = it.authorities
-                providerInfo.grantUriPermissions = true //插件没有权限管理机制
-
+                providerInfo.grantUriPermissions = it.grantUriPermissions
                 contentProvider?.attachInfo(context, providerInfo)
                 providerMap[it.authorities] = contentProvider
             } catch (e: Exception) {

--- a/projects/sdk/core/manifest-parser/src/main/kotlin/com/tencent/shadow/core/manifest_parser/AndroidManifestKeys.kt
+++ b/projects/sdk/core/manifest-parser/src/main/kotlin/com/tencent/shadow/core/manifest_parser/AndroidManifestKeys.kt
@@ -17,6 +17,7 @@ sealed class AndroidManifestKeys {
         const val service = "service"
         const val provider = "provider"
         const val receiver = "receiver"
+        const val grantUriPermissions="android:grantUriPermissions"
     }
 }
 typealias ComponentMapKey = String

--- a/projects/sdk/core/manifest-parser/src/main/kotlin/com/tencent/shadow/core/manifest_parser/AndroidManifestReader.kt
+++ b/projects/sdk/core/manifest-parser/src/main/kotlin/com/tencent/shadow/core/manifest_parser/AndroidManifestReader.kt
@@ -157,6 +157,7 @@ class AndroidManifestReader {
         val providerMap = parseComponent(element).toMutableMap()
 
         providerMap.putAttributeIfNotNull(element, AndroidManifestKeys.authorities)
+        providerMap.putAttributeIfNotNull(element,AndroidManifestKeys.grantUriPermissions)
 
         return providerMap
     }

--- a/projects/sdk/core/manifest-parser/src/main/kotlin/com/tencent/shadow/core/manifest_parser/PluginManifestGenerator.kt
+++ b/projects/sdk/core/manifest-parser/src/main/kotlin/com/tencent/shadow/core/manifest_parser/PluginManifestGenerator.kt
@@ -241,6 +241,9 @@ private class PluginManifestBuilder(
 
     private fun toNewProviderInfo(componentMap: ComponentMap): String {
         val authoritiesValue = componentMap[AndroidManifestKeys.authorities]
+        //如果未传值使用android.content.pm.ProviderInfo.grantUriPermissions的默认值false
+        val grantUriPermissions=componentMap[AndroidManifestKeys.grantUriPermissions]?:false
+
         val authoritiesLiteral =
             if (authoritiesValue != null) {
                 "\"${authoritiesValue}\""
@@ -249,7 +252,7 @@ private class PluginManifestBuilder(
             }
 
         return "new com.tencent.shadow.core.runtime.PluginManifest" +
-                ".ProviderInfo(\"${componentMap[AndroidManifestKeys.name]}\", $authoritiesLiteral)"
+                ".ProviderInfo(\"${componentMap[AndroidManifestKeys.name]}\", $authoritiesLiteral,$grantUriPermissions)"
     }
 
     companion object {

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginManifest.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/PluginManifest.java
@@ -132,10 +132,12 @@ public interface PluginManifest {
 
     final class ProviderInfo extends ComponentInfo {
         public final String authorities;
+        public final boolean grantUriPermissions;
 
-        public ProviderInfo(String className, String authorities) {
+        public ProviderInfo(String className, String authorities,boolean grantUriPermissions) {
             super(className);
             this.authorities = authorities;
+            this.grantUriPermissions=grantUriPermissions;
         }
     }
 

--- a/projects/test/plugin/general-cases/test-plugin-general-cases/src/main/AndroidManifest.xml
+++ b/projects/test/plugin/general-cases/test-plugin-general-cases/src/main/AndroidManifest.xml
@@ -99,6 +99,7 @@
 
         <provider
             android:name=".lib.usecases.provider.TestProvider"
+            android:grantUriPermissions="true"
             android:authorities="${applicationId}.provider.test" />
 
         <provider

--- a/projects/test/plugin/general-cases/test-plugin-general-cases/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/provider/TestProvider.java
+++ b/projects/test/plugin/general-cases/test-plugin-general-cases/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/provider/TestProvider.java
@@ -20,7 +20,9 @@ package com.tencent.shadow.test.plugin.general_cases.lib.usecases.provider;
 
 import android.content.ContentProvider;
 import android.content.ContentValues;
+import android.content.Context;
 import android.content.UriMatcher;
+import android.content.pm.ProviderInfo;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
@@ -39,6 +41,15 @@ public class TestProvider extends ContentProvider {
     public boolean onCreate() {
         mOpenHelper = new TestDBHelper(getContext());
         return true;
+    }
+
+    @Override
+    public void attachInfo(Context context, ProviderInfo info) {
+        super.attachInfo(context, info);
+        //用于测试是否读取了Manifest中的grantUriPermissions值,在实际生产中这里并不需要抛出异常
+        if (!info.grantUriPermissions) {
+            throw new IllegalStateException("读取ProviderInfo.grantUriPermissions失败");
+        }
     }
 
 


### PR DESCRIPTION
修复https://github.com/Tencent/Shadow/issues/855中遇到的问题
修复插件中provider的grantUriPermissions为false但shadow默认为true的问题