### PR TITLE
fix(core.runtime): unregisterReceiver时反注册错误导致报异常Receiver not registered

### DIFF
--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowContext.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowContext.java
@@ -288,11 +288,16 @@ public class ShadowContext extends SubDirContextThemeWrapper {
 
     @Override
     public void unregisterReceiver(BroadcastReceiver receiver) {
-        BroadcastReceiverWrapper wrapper = receiverToWrapper(receiver);
-        if (wrapper != null) {
-            super.unregisterReceiver(wrapper);
-        } else {
-            super.unregisterReceiver(receiver);
+        synchronized (mReceiverWrapperMap) {
+            WeakReference<BroadcastReceiverWrapper> weakReference
+                    = mReceiverWrapperMap.get(receiver);
+            BroadcastReceiverWrapper wrapper = weakReference == null ? null : weakReference.get();
+            if (null != wrapper) {
+                super.unregisterReceiver(wrapper);
+            } else {
+                super.unregisterReceiver(receiver);
+            }
+            mReceiverWrapperMap.remove(receiver);
         }
     }
 


### PR DESCRIPTION
如 https://github.com/Tencent/Shadow/issues/865  中反馈的问题
修复ShadowContext反注册时报异常Receiver not registered: com.tencent.shadow.core.runtime.BroadcastReceiverWrapper 的问题
