### PR TITLE
fix(core.runtime): ReceiverWrapperMap改为由ShadowApplication持有的单例

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/blocs/CreateApplicationBloc.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/blocs/CreateApplicationBloc.kt
@@ -60,6 +60,7 @@ object CreateApplicationBloc {
             shadowApplication.applicationInfo = pluginApplicationInfo
             shadowApplication.setBusinessName(loadParameters.businessName)
             shadowApplication.setPluginPartKey(partKey)
+            shadowApplication.setShadowApplication(shadowApplication)
 
             //和ShadowActivityDelegate.initPluginActivity一样，attachBaseContext放到最后
             shadowApplication.setHostApplicationContextAsBase(hostAppContext)

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowApplication.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowApplication.java
@@ -29,8 +29,10 @@ import android.content.IntentFilter;
 import android.content.res.Configuration;
 import android.os.Build;
 
+import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * 用于在plugin-loader中调用假的Application方法的接口
@@ -47,6 +49,22 @@ public class ShadowApplication extends ShadowContext {
             = new ShadowActivityLifecycleCallbacks.Holder();
 
     public boolean isCallOnCreate;
+
+    /**
+     * BroadcastReceiver到BroadcastReceiverWrapper对象到映射关系
+     * <p>
+     * 采用WeakHashMap<BroadcastReceiver, WeakReference<BroadcastReceiverWrapper>>
+     * 使key和value都采用弱引用持有，以保持原本BroadcastReceiver的GC回收时机。
+     * <p>
+     * BroadcastReceiver由原有业务代码强持有（也可能不持有），BroadcastReceiver原本在registerReceiver
+     * 之后交由系统持有，现在由BroadcastReceiverWrapper代替它被系统强持有。
+     * 所以BroadcastReceiverWrapper强引用持有BroadcastReceiver，保持了系统强引用BroadcastReceiver的关系。
+     * <p>
+     * 如果业务原本没有持有BroadcastReceiver，也就不会再有unregisterReceiver调用来，
+     * 也就不需要Map中有wrapper对应关系，所以用弱引用持有此关系没有影响。
+     */
+    final private Map<BroadcastReceiver, WeakReference<BroadcastReceiverWrapper>>
+            mReceiverWrapperMap = new WeakHashMap<>();
 
     @Override
     public Context getApplicationContext() {
@@ -175,5 +193,21 @@ public class ShadowApplication extends ShadowContext {
     @SuppressLint("NewApi")
     public static String getProcessName() {
         return Application.getProcessName();
+    }
+
+    public BroadcastReceiverWrapper receiverToWrapper(BroadcastReceiver receiver) {
+        if (receiver == null) {
+            return null;
+        }
+        synchronized (mReceiverWrapperMap) {
+            WeakReference<BroadcastReceiverWrapper> weakReference
+                    = mReceiverWrapperMap.get(receiver);
+            BroadcastReceiverWrapper wrapper = weakReference == null ? null : weakReference.get();
+            if (wrapper == null) {
+                wrapper = new BroadcastReceiverWrapper(receiver, this);
+                mReceiverWrapperMap.put(receiver, new WeakReference<>(wrapper));
+            }
+            return wrapper;
+        }
     }
 }


### PR DESCRIPTION
receiver的注册和反注册可能由不同的context完成。

fixup! d2f3995d
fix #865