### PR TITLE
fix: 修复--package-id的错误指引

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -4,4 +4,5 @@ defaultIgnores: false
 rules:
   #允许中文
   subject-case: [ 0 ]
+  footer-max-line-length: [ 0 ]
 helpUrl: https://www.conventionalcommits.org/zh-hans/v1.0.0/

--- a/projects/sample/source/sample-plugin/sample-app/build.gradle
+++ b/projects/sample/source/sample-plugin/sample-app/build.gradle
@@ -51,9 +51,9 @@ android {
         abortOnError false
     }
 
-    // 将插件的资源ID分区改为大于0x7f的值，使其不同于宿主默认的0x7f
+    // 将插件的资源ID分区改为和宿主0x7F不同的值
     aaptOptions {
-        additionalParameters "--package-id", "0x80"
+        additionalParameters "--package-id", "0x7E", "--allow-reserved-package-id"
     }
 }
 

--- a/projects/sample/source/sample-plugin/sample-base/build.gradle
+++ b/projects/sample/source/sample-plugin/sample-base/build.gradle
@@ -47,9 +47,9 @@ android {
         }
     }
 
-    // 将插件的资源ID分区改为大于0x7f的值，使其不同于宿主默认的0x7f
+    // 将插件的资源ID分区改为和宿主0x7F不同的值
     aaptOptions {
-        additionalParameters "--package-id", "0x80"
+        additionalParameters "--package-id", "0x7E", "--allow-reserved-package-id"
     }
 
     lintOptions {

--- a/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/AGPCompat.kt
+++ b/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/AGPCompat.kt
@@ -19,6 +19,7 @@
 package com.tencent.shadow.core.gradle
 
 import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.BaseVariantOutput
 import com.android.build.gradle.internal.dsl.ProductFlavor
 import org.gradle.api.Project
@@ -36,4 +37,5 @@ internal interface AGPCompat {
     fun getProcessManifestTask(output: BaseVariantOutput): Task
     fun getProcessResourcesTask(output: BaseVariantOutput): Task
     fun getAaptAdditionalParameters(processResourcesTask: Task): List<String>
+    fun getMinSdkVersion(pluginVariant: ApplicationVariant): Int
 }

--- a/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/AGPCompatImpl.kt
+++ b/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/AGPCompatImpl.kt
@@ -2,11 +2,13 @@ package com.tencent.shadow.core.gradle
 
 import com.android.SdkConstants
 import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.BaseVariantOutput
 import com.android.build.gradle.internal.dsl.ProductFlavor
 import com.android.build.gradle.internal.res.LinkApplicationAndroidResourcesTask
 import com.android.build.gradle.tasks.ProcessApplicationManifest
 import com.android.build.gradle.tasks.ProcessMultiApkApplicationManifest
+import com.android.sdklib.AndroidVersion.VersionCodes
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.provider.Property
@@ -125,6 +127,12 @@ internal class AGPCompatImpl : AGPCompat {
             // 设置Default主要是为了IDE中的Build Variants上下文自动选择时不要选成插件，
             // 以便在IDE直接运行插件apk模块时运行Normal版本
         }
+    }
+
+    override fun getMinSdkVersion(pluginVariant: ApplicationVariant): Int {
+        // AGP在版本升级中修改了MergedFlavor的包名，但是它实现的ProductFlavor接口没有变
+        val mergedFlavor = pluginVariant.mergedFlavor as com.android.builder.model.ProductFlavor
+        return mergedFlavor.minSdkVersion?.apiLevel ?: VersionCodes.BASE
     }
 
     companion object {

--- a/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/plugin1/build.gradle
+++ b/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/plugin1/build.gradle
@@ -47,9 +47,9 @@ android {
         versionName VERSION_NAME
     }
 
-    // 将插件的资源ID分区改为大于0x7f的值，使其不同于宿主默认的0x7f
+    // 将插件的资源ID分区改为和宿主0x7F不同的值
     aaptOptions {
-        additionalParameters "--package-id", "0x80"
+        additionalParameters "--package-id", "0x7E", "--allow-reserved-package-id"
     }
 }
 

--- a/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/plugin2/build.gradle
+++ b/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/plugin2/build.gradle
@@ -47,9 +47,9 @@ android {
         versionName VERSION_NAME
     }
 
-    // 将插件的资源ID分区改为大于0x7f的值，使其不同于宿主默认的0x7f
+    // 将插件的资源ID分区改为和宿主0x7F不同的值
     aaptOptions {
-        additionalParameters "--package-id", "0x80"
+        additionalParameters "--package-id", "0x7E", "--allow-reserved-package-id"
     }
 }
 

--- a/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/ViewIdTest.java
+++ b/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_main/ViewIdTest.java
@@ -1,0 +1,49 @@
+/*
+ * Tencent is pleased to support the open source community by making Tencent Shadow available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.tencent.shadow.test.cases.plugin_main;
+
+import android.content.Intent;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(AndroidJUnit4.class)
+public class ViewIdTest extends PluginMainAppTest {
+
+    @Override
+    protected Intent getLaunchIntent() {
+        Intent pluginIntent = new Intent();
+        String packageName = ApplicationProvider.getApplicationContext().getPackageName();
+        pluginIntent.setClassName(
+                packageName,
+                "com.tencent.shadow.test.plugin.general_cases.lib.usecases.view.TestViewIdActivity"
+        );
+        return pluginIntent;
+    }
+
+    @Test
+    public void testAllIdEquals() {
+        matchTextWithViewTag("isSame", Boolean.toString(true));
+    }
+
+}

--- a/projects/test/gradle-plugin-agp-compat-test/stub-project/build.gradle
+++ b/projects/test/gradle-plugin-agp-compat-test/stub-project/build.gradle
@@ -58,9 +58,9 @@ android {
 
     }
 
-    // 将插件的资源ID分区改为大于0x7f的值，使其不同于宿主默认的0x7f
+    // 将插件的资源ID分区改为和宿主0x7F不同的值
     aaptOptions {
-        additionalParameters "--package-id", "0x80"
+        additionalParameters "--package-id", "0x7E", "--allow-reserved-package-id"
     }
 }
 

--- a/projects/test/gradle-plugin-agp-compat-test/test.sh
+++ b/projects/test/gradle-plugin-agp-compat-test/test.sh
@@ -44,5 +44,8 @@ testUnderAGPVersion 3.5.0
 testUnderAGPVersion 3.4.0
 testUnderAGPVersion 3.3.0
 testUnderAGPVersion 3.2.0
-testUnderAGPVersion 3.1.0
+
+# 3.1.0在配合aapt2使用--package-id选项时不能设置小于0x7f的值，因此不再支持
+#testUnderAGPVersion 3.1.0
+
 #更低的版本支持成本过高

--- a/projects/test/plugin/androidx-cases/test-plugin-androidx-cases/build.gradle
+++ b/projects/test/plugin/androidx-cases/test-plugin-androidx-cases/build.gradle
@@ -30,9 +30,9 @@ android {
         }
     }
 
-    // 将插件的资源ID分区改为大于0x7f的值，使其不同于宿主默认的0x7f
+    // 将插件的资源ID分区改为和宿主0x7F不同的值
     aaptOptions {
-        additionalParameters "--package-id", "0x80"
+        additionalParameters "--package-id", "0x7E", "--allow-reserved-package-id"
     }
 
     lintOptions {

--- a/projects/test/plugin/general-cases/test-plugin-general-cases/build.gradle
+++ b/projects/test/plugin/general-cases/test-plugin-general-cases/build.gradle
@@ -34,9 +34,9 @@ android {
         abortOnError false
     }
 
-    // 将插件的资源ID分区改为大于0x7f的值，使其不同于宿主默认的0x7f
+    // 将插件的资源ID分区改为和宿主0x7F不同的值
     aaptOptions {
-        additionalParameters "--package-id", "0x80"
+        additionalParameters "--package-id", "0x7E", "--allow-reserved-package-id"
     }
 }
 

--- a/projects/test/plugin/general-cases/test-plugin-general-cases/src/main/AndroidManifest.xml
+++ b/projects/test/plugin/general-cases/test-plugin-general-cases/src/main/AndroidManifest.xml
@@ -98,6 +98,7 @@
         <activity android:name=".lib.usecases.classloader.TestBootClassloaderActivity" />
         <activity android:name=".lib.usecases.context.TestLayoutInflaterActivity" />
         <activity android:name=".lib.usecases.context.ContextGetPackageCodePathTestActivity" />
+        <activity android:name=".lib.usecases.view.TestViewIdActivity" />
 
         <provider
             android:name=".lib.usecases.provider.TestProvider"

--- a/projects/test/plugin/general-cases/test-plugin-general-cases/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/view/TestViewIdActivity.java
+++ b/projects/test/plugin/general-cases/test-plugin-general-cases/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/view/TestViewIdActivity.java
@@ -1,0 +1,51 @@
+package com.tencent.shadow.test.plugin.general_cases.lib.usecases.view;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.tencent.shadow.test.plugin.general_cases.R;
+import com.tencent.shadow.test.plugin.general_cases.lib.gallery.util.UiUtil;
+
+public class TestViewIdActivity extends Activity {
+
+    private ViewGroup mItemViewGroup;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        View inflateView = getLayoutInflater().inflate(R.layout.layout_test_view_id, null);
+        int idInXml = inflateView.getId();
+        int idInJava = R.id.test_id;
+        int idInResources = getResources().getIdentifier("test_id", "id", getPackageName());
+
+        mItemViewGroup = UiUtil.setActivityContentView(this);
+
+        boolean isSame = idInXml == idInJava && idInXml == idInResources;
+
+        addItem("idInXml", idInXml);
+        addItem("idInJava", idInJava);
+        addItem("idInResources", idInResources);
+        mItemViewGroup.addView(
+                UiUtil.makeItem(
+                        this,
+                        "isSame",
+                        "isSame",
+                        Boolean.toString(isSame)
+                )
+        );
+    }
+
+    private void addItem(String key, int value) {
+        ViewGroup item = UiUtil.makeItem(
+                this,
+                key,
+                key,
+                Integer.toHexString(value)
+        );
+        mItemViewGroup.addView(item);
+    }
+}

--- a/projects/test/plugin/general-cases/test-plugin-general-cases/src/main/res/layout/layout_test_view_id.xml
+++ b/projects/test/plugin/general-cases/test-plugin-general-cases/src/main/res/layout/layout_test_view_id.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/test_id"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:orientation="vertical">
+
+</LinearLayout>

--- a/projects/test/plugin/particular-cases/plugin-service-for-host/build.gradle
+++ b/projects/test/plugin/particular-cases/plugin-service-for-host/build.gradle
@@ -29,9 +29,9 @@ android {
         }
     }
 
-    // 将插件的资源ID分区改为大于0x7f的值，使其不同于宿主默认的0x7f
+    // 将插件的资源ID分区改为和宿主0x7F不同的值
     aaptOptions {
-        additionalParameters "--package-id", "0x80"
+        additionalParameters "--package-id", "0x7E", "--allow-reserved-package-id"
     }
 
     lintOptions {


### PR DESCRIPTION
为了兼容minSDK小于26，且packageId大于0x7f时Android系统的bug，aapt对id进行了修改，
导致Resources中记录的id值和layout中使用的id值不一致。
但是minSDK小于26时可以使用--allow-reserved-package-id选项使用小于0x7f的值。

https://android.googlesource.com/platform/frameworks/base/+/master/tools/aapt2/readme.md#version-2_14
https://developer.android.com/studio/command-line/aapt2#link_options
fixup! f208e8be
fixup! #890