### PR TITLE
chore: 将android.jar重新添加回compileOnly中

### DIFF
--- a/projects/sdk/coding/common-jar-settings/src/main/kotlin/com/tencent/shadow/coding/common_jar_settings/CommonJarSettingsPlugin.kt
+++ b/projects/sdk/coding/common-jar-settings/src/main/kotlin/com/tencent/shadow/coding/common_jar_settings/CommonJarSettingsPlugin.kt
@@ -17,9 +17,13 @@ class CommonJarSettingsPlugin : Plugin<Project> {
         java.sourceCompatibility = JavaVersion.VERSION_1_7
         java.targetCompatibility = JavaVersion.VERSION_1_7
 
+        val androidJar = project.files(AndroidJar.ANDROID_JAR_PATH)
         // 将android.jar设置为这些jar工程的bootclasspath，以便javac编译时使用的JDK标准库采用android平台的定义
         project.tasks.withType(JavaCompile::class.java) {
-            it.options.bootstrapClasspath = project.files(AndroidJar.ANDROID_JAR_PATH)
+            it.options.bootstrapClasspath = androidJar
         }
+
+        // IDE不会自动索引bootstrapClasspath，所以把bootstrapClasspath重复添加到compileOnly中
+        project.dependencies.add("compileOnly", androidJar)
     }
 }


### PR DESCRIPTION
兼容IDE不索引bootclasspath的问题。

fix #905
fixup! https://github.com/Tencent/Shadow/commit/51eb88496cedf39c83ebde8450fdf1ae61711227
