### PR TITLE
test: 宿主供插件依赖的类都需要在Proguard中keep住

### DIFF
--- a/projects/sample/source/sample-host-lib/sample-host-lib.pro
+++ b/projects/sample/source/sample-host-lib/sample-host-lib.pro
@@ -1,4 +1,4 @@
 #让宿主在打包时能够keep住插件要使用到的类名和方法
--keep class com.tencent.shadow.sample.host.lib.HostUiLayerProvider{
+-keep class com.tencent.shadow.sample.host.lib.*{
     public *;
 }


### PR DESCRIPTION
否则sample-host在Release模式下运行会因为找不到类而Crash。

在sample中，sample-host-lib中的所有类都是准备让插件依赖的。

fix #919