### PR TITLE
test: 配置sample插件Release版开启Proguard

### DIFF
--- a/projects/sample/source/sample-plugin/sample-app/build.gradle
+++ b/projects/sample/source/sample-plugin/sample-app/build.gradle
@@ -32,7 +32,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
 
             signingConfig signingConfigs.create("release")

--- a/projects/sample/source/sample-plugin/sample-app/proguard-rules.pro
+++ b/projects/sample/source/sample-plugin/sample-app/proguard-rules.pro
@@ -15,3 +15,6 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+#这是Shadow在编译期将AndroidManifest.xml中所需信息生成的Java类，没有被代码自然引用，所以需要手工keep住。
+-keep class com.tencent.shadow.core.manifest_parser.PluginManifest{*;}

--- a/projects/sample/source/sample-plugin/sample-base-lib/build.gradle
+++ b/projects/sample/source/sample-plugin/sample-base-lib/build.gradle
@@ -14,6 +14,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'proguard-rules.pro'
 
             signingConfig signingConfigs.create("release")
             signingConfig.initWith(buildTypes.debug.signingConfig)

--- a/projects/sample/source/sample-plugin/sample-base-lib/proguard-rules.pro
+++ b/projects/sample/source/sample-plugin/sample-base-lib/proguard-rules.pro
@@ -15,3 +15,9 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# 这是供sample-app模块依赖的类
+-keep class com.tencent.shadow.sample.plugin.app.lib.gallery.cases.UseCaseManager{*;}
+-keep class com.tencent.shadow.sample.plugin.app.lib.gallery.cases.entity.*{*;}
+-keep class com.tencent.shadow.sample.plugin.app.lib.gallery.BaseActivity{*;}
+-keep class com.tencent.shadow.sample.plugin.app.lib.gallery.util.*{*;}

--- a/projects/sample/source/sample-plugin/sample-base/build.gradle
+++ b/projects/sample/source/sample-plugin/sample-base/build.gradle
@@ -32,7 +32,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
 
             signingConfig signingConfigs.create("release")

--- a/projects/sample/source/sample-plugin/sample-base/proguard-rules.pro
+++ b/projects/sample/source/sample-plugin/sample-base/proguard-rules.pro
@@ -15,3 +15,6 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+#这是Shadow在编译期将AndroidManifest.xml中所需信息生成的Java类，没有被代码自然引用，所以需要手工keep住。
+-keep class com.tencent.shadow.core.manifest_parser.PluginManifest{*;}


### PR DESCRIPTION
开启Proguard后，注意插件中要keep住PluginManifest，因为它没有直接引用，Proguard会将它作为无用类删掉。
对于跨插件的依赖也要keep住，因为不同插件的混淆规则不同，加载类时会找不到。

fix #916