### PR TITLE
fix: API小于等于25时采用MixResource方案

### DIFF
--- a/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/CreateResourceTest.java
+++ b/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/CreateResourceTest.java
@@ -1,0 +1,23 @@
+package com.tencent.shadow.test;
+
+import com.tencent.shadow.test.cases.plugin_androidx.AppCompatActivityTest;
+import com.tencent.shadow.test.cases.plugin_main.ThemeTest;
+import com.tencent.shadow.test.cases.plugin_main.ViewIdTest;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * com.tencent.shadow.core.loader.blocs.CreateResourceBloc
+ * 改动相关测试
+ */
+@RunWith(Suite.class)
+@Ignore("避免自动化全量测试时重复这些测试")
+@Suite.SuiteClasses({
+        ViewIdTest.class,
+        ThemeTest.class,
+        AppCompatActivityTest.class,
+})
+public class CreateResourceTest {
+}


### PR DESCRIPTION
因调用addAssetPath方法也无法满足CreateResourceTest涉及的场景。
只在API25及以下依赖Resources的构造器，不会受未来Resources类变化影响。

此提交在API 16,19,21,22,23,24,25,26,28,31的虚拟机上测试了CreateResourceTest正常。

fix #915