### PR TITLE
fix(dynamic.manager): 修复一个无法unBindService的bug.

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/managers/PluginServiceManager.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/managers/PluginServiceManager.kt
@@ -222,6 +222,8 @@ private open class UnsafePluginServiceManager(
                 // 结束该service
                 isPluginServiceStopped = destroyServiceIfNeed(componentName)
 
+                connection.onServiceDisconnected(componentName)
+
                 break
             }
         }

--- a/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_service/PluginIntentServiceConnectionTest.java
+++ b/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_service/PluginIntentServiceConnectionTest.java
@@ -40,6 +40,9 @@ public class PluginIntentServiceConnectionTest extends PluginServiceAppTest {
         matchTextWithViewTag("STATUS_VIEW_TAG", "onServiceConnected");
         matchTextWithViewTag("PACKAGE_VIEW_TAG", packageName);
         matchTextWithViewTag("CLASS_VIEW_TAG", ServiceClassName);
+
+        //结束Service，避免影响其他用例
+        Espresso.onView(ViewMatchers.withTagValue(Matchers.<Object>is("STOP_BUTTON_TAG"))).perform(ViewActions.click());
     }
 
     @Test

--- a/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_service/PluginServiceConnectionTest.java
+++ b/projects/test/dynamic/host/test-dynamic-host/src/androidTest/java/com/tencent/shadow/test/cases/plugin_service/PluginServiceConnectionTest.java
@@ -40,6 +40,23 @@ public class PluginServiceConnectionTest extends PluginServiceAppTest {
         matchTextWithViewTag("STATUS_VIEW_TAG", "onServiceConnected");
         matchTextWithViewTag("PACKAGE_VIEW_TAG", packageName);
         matchTextWithViewTag("CLASS_VIEW_TAG", ServiceClassName);
+
+        //结束Service，避免影响其他用例
+        Espresso.onView(ViewMatchers.withTagValue(Matchers.<Object>is("STOP_BUTTON_TAG"))).perform(ViewActions.click());
+    }
+
+    @Test
+    public void testUnbindService() {
+        Espresso.onView(ViewMatchers.withTagValue(Matchers.<Object>is("BIND_BUTTON_TAG"))).perform(ViewActions.click());
+        matchTextWithViewTag("STATUS_VIEW_TAG", "onServiceConnected");
+        Espresso.onView(ViewMatchers.withTagValue(Matchers.<Object>is("UNBIND_BUTTON_TAG"))).perform(ViewActions.click());
+
+        // 测试Service在onUnbind时收到的Intent是否还是bind时传入的
+        matchTextWithViewTag("MAGIC_NUMBER_MATCH_TAG", Boolean.toString(true));
+
+        matchTextWithViewTag("STATUS_VIEW_TAG", "onServiceDisconnected");
+        matchTextWithViewTag("PACKAGE_VIEW_TAG", packageName);
+        matchTextWithViewTag("CLASS_VIEW_TAG", ServiceClassName);
     }
 
     @Test

--- a/projects/test/dynamic/manager/test-dynamic-manager/src/main/java/com/tencent/shadow/test/dynamic/manager/ServiceTestDynamicPluginManager.java
+++ b/projects/test/dynamic/manager/test-dynamic-manager/src/main/java/com/tencent/shadow/test/dynamic/manager/ServiceTestDynamicPluginManager.java
@@ -26,6 +26,7 @@ import android.view.View;
 
 import com.tencent.shadow.core.manager.installplugin.InstalledPlugin;
 import com.tencent.shadow.dynamic.host.EnterCallback;
+import com.tencent.shadow.test.cases.PluginIntentServiceConnectionTestCase;
 import com.tencent.shadow.test.cases.PluginServiceConnectionTestCase;
 import com.tencent.shadow.test.lib.constant.Constant;
 import com.tencent.shadow.test.lib.test_manager.TestManager;
@@ -80,7 +81,7 @@ public class ServiceTestDynamicPluginManager extends FastPluginManager {
                 systemExitServiceCase.prepareUi();
                 break;
             case "com.tencent.shadow.test.plugin.particular_cases.plugin_service_for_host.SystemExitIntentService":
-                PluginServiceConnectionTestCase systemExitIntentService = new PluginServiceConnectionTestCase(mPluginLoader, pluginIntent);
+                PluginIntentServiceConnectionTestCase systemExitIntentService = new PluginIntentServiceConnectionTestCase(mPluginLoader, pluginIntent);
                 systemExitIntentService.prepareUi();
                 break;
             default:

--- a/projects/test/plugin/particular-cases/plugin-service-for-host/src/main/java/com/tencent/shadow/test/plugin/particular_cases/plugin_service_for_host/SystemExitService.java
+++ b/projects/test/plugin/particular-cases/plugin-service-for-host/src/main/java/com/tencent/shadow/test/plugin/particular_cases/plugin_service_for_host/SystemExitService.java
@@ -7,6 +7,10 @@ import android.os.IBinder;
 import android.os.Parcel;
 import android.os.RemoteException;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+
 @SuppressWarnings("NullableProblems")
 public class SystemExitService extends Service {
     @Override
@@ -22,5 +26,20 @@ public class SystemExitService extends Service {
                 return super.onTransact(code, data, reply, flags);
             }
         };
+    }
+
+    @Override
+    public boolean onUnbind(Intent intent) {
+        long magic_number = intent.getLongExtra("magic_number", 0L);
+        File outputFile = new File(getFilesDir(), "SystemExitService.onUnbind");
+        try (BufferedWriter bufferedWriter
+                     = new BufferedWriter(new FileWriter(outputFile, false))) {
+            bufferedWriter.append(Long.toString(magic_number));
+            bufferedWriter.flush();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return super.onUnbind(intent);
     }
 }


### PR DESCRIPTION
添加一个map保存创建的PluginServiceConnectionBinder，保证在BinderPluginLoader 中 bindService 时传递的 PluginServiceConnectionBinder 对象与 unBindService 时传递的 PluginServiceConnectionBinder 对象相同。 这样才能在 DynamicPluginLoader 的 unbindService 时获取到和 bindPluginService 时相同的 ServiceConnection 。 此时才能 解绑成功。