### PR TITLE
fix(core.runtime): 回调BroadcastReceiver前设置插件ClassLoader到Intent

### DIFF
--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/BroadcastReceiverWrapper.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/BroadcastReceiverWrapper.java
@@ -17,6 +17,7 @@ public class BroadcastReceiverWrapper extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
+        intent.setExtrasClassLoader(mShadowContext.mPluginClassLoader);
         mRealBroadcastReceiver.onReceive(mShadowContext, intent);
     }
 }

--- a/projects/test/plugin/general-cases/test-plugin-general-cases/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/receiver/TestReceiverActivity.java
+++ b/projects/test/plugin/general-cases/test-plugin-general-cases/src/main/java/com/tencent/shadow/test/plugin/general_cases/lib/usecases/receiver/TestReceiverActivity.java
@@ -24,6 +24,8 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import android.view.View;
 import android.widget.TextView;
@@ -76,6 +78,7 @@ public class TestReceiverActivity extends WithIdlingResourceActivity {
         mIdlingResource.setIdleState(false);
         Intent intent = new Intent(INTENT_NORMAL_ACTION);
         intent.putExtra("msg", MSG_NORMAL);
+        intent.putExtra("custom_parcel", new CustomParcel());
         sendBroadcast(intent);
     }
 
@@ -109,4 +112,32 @@ public class TestReceiverActivity extends WithIdlingResourceActivity {
         }
     }
 
+    public static class CustomParcel implements Parcelable {
+        public CustomParcel() {
+        }
+
+        protected CustomParcel(Parcel in) {
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+        }
+
+        @Override
+        public int describeContents() {
+            return 0;
+        }
+
+        public static final Creator<CustomParcel> CREATOR = new Creator<CustomParcel>() {
+            @Override
+            public CustomParcel createFromParcel(Parcel in) {
+                return new CustomParcel(in);
+            }
+
+            @Override
+            public CustomParcel[] newArray(int size) {
+                return new CustomParcel[size];
+            }
+        };
+    }
 }


### PR DESCRIPTION
修复传自定义parcel时无法找到类的问题。