### PR TITLE
fix(core.loader): 转调vararg方法时应该在参数前加*

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/blocs/CreateResourceBloc.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/blocs/CreateResourceBloc.kt
@@ -179,7 +179,7 @@ private class MixResources(
         tryMainThenShared { it.getString(id) }
 
     override fun getString(id: Int, vararg formatArgs: Any?) =
-        tryMainThenShared { it.getString(id, formatArgs) }
+        tryMainThenShared { it.getString(id, *formatArgs) }
 
 
     override fun getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any?) =


### PR DESCRIPTION
否则参数会被再多套一层Object[]。

API 18自动化测试可复现此问题。