### PR TITLE
ci: 添加全量AVD版本测试脚本

### DIFF
--- a/.github/workflows/test-avd-16.yml
+++ b/.github/workflows/test-avd-16.yml
@@ -1,0 +1,12 @@
+name: daily-test-avd-16
+
+on:
+  push:
+    branches: [ test-all-avd ]
+
+jobs:
+  job1:
+    uses: ./.github/workflows/test-avd.yml
+    with:
+      api-level: 16
+      arch: x86

--- a/.github/workflows/test-avd-17.yml
+++ b/.github/workflows/test-avd-17.yml
@@ -1,0 +1,12 @@
+name: daily-test-avd-17
+
+on:
+  push:
+    branches: [ test-all-avd ]
+
+jobs:
+  job1:
+    uses: ./.github/workflows/test-avd.yml
+    with:
+      api-level: 17
+      arch: x86

--- a/.github/workflows/test-avd-18.yml
+++ b/.github/workflows/test-avd-18.yml
@@ -1,0 +1,12 @@
+name: daily-test-avd-18
+
+on:
+  push:
+    branches: [ test-all-avd ]
+
+jobs:
+  job1:
+    uses: ./.github/workflows/test-avd.yml
+    with:
+      api-level: 18
+      arch: x86

--- a/.github/workflows/test-avd-19.yml
+++ b/.github/workflows/test-avd-19.yml
@@ -1,0 +1,12 @@
+name: daily-test-avd-19
+
+on:
+  push:
+    branches: [ test-all-avd ]
+
+jobs:
+  job1:
+    uses: ./.github/workflows/test-avd.yml
+    with:
+      api-level: 19
+      arch: x86

--- a/.github/workflows/test-avd-21.yml
+++ b/.github/workflows/test-avd-21.yml
@@ -1,0 +1,12 @@
+name: daily-test-avd-21
+
+on:
+  push:
+    branches: [ test-all-avd ]
+
+jobs:
+  job1:
+    uses: ./.github/workflows/test-avd.yml
+    with:
+      api-level: 21
+      arch: x86_64

--- a/.github/workflows/test-avd-22.yml
+++ b/.github/workflows/test-avd-22.yml
@@ -1,0 +1,12 @@
+name: daily-test-avd-22
+
+on:
+  push:
+    branches: [ test-all-avd ]
+
+jobs:
+  job1:
+    uses: ./.github/workflows/test-avd.yml
+    with:
+      api-level: 22
+      arch: x86_64

--- a/.github/workflows/test-avd-23.yml
+++ b/.github/workflows/test-avd-23.yml
@@ -1,0 +1,12 @@
+name: daily-test-avd-23
+
+on:
+  push:
+    branches: [ test-all-avd ]
+
+jobs:
+  job1:
+    uses: ./.github/workflows/test-avd.yml
+    with:
+      api-level: 23
+      arch: x86_64

--- a/.github/workflows/test-avd-24.yml
+++ b/.github/workflows/test-avd-24.yml
@@ -1,0 +1,12 @@
+name: daily-test-avd-24
+
+on:
+  push:
+    branches: [ test-all-avd ]
+
+jobs:
+  job1:
+    uses: ./.github/workflows/test-avd.yml
+    with:
+      api-level: 24
+      arch: x86_64

--- a/.github/workflows/test-avd-25.yml
+++ b/.github/workflows/test-avd-25.yml
@@ -1,0 +1,12 @@
+name: daily-test-avd-25
+
+on:
+  push:
+    branches: [ test-all-avd ]
+
+jobs:
+  job1:
+    uses: ./.github/workflows/test-avd.yml
+    with:
+      api-level: 25
+      arch: x86_64

--- a/.github/workflows/test-avd-26.yml
+++ b/.github/workflows/test-avd-26.yml
@@ -1,0 +1,12 @@
+name: daily-test-avd-26
+
+on:
+  push:
+    branches: [ test-all-avd ]
+
+jobs:
+  job1:
+    uses: ./.github/workflows/test-avd.yml
+    with:
+      api-level: 26
+      arch: x86_64

--- a/.github/workflows/test-avd-27.yml
+++ b/.github/workflows/test-avd-27.yml
@@ -1,0 +1,12 @@
+name: daily-test-avd-27
+
+on:
+  push:
+    branches: [ test-all-avd ]
+
+jobs:
+  job1:
+    uses: ./.github/workflows/test-avd.yml
+    with:
+      api-level: 27
+      arch: x86_64

--- a/.github/workflows/test-avd-28.yml
+++ b/.github/workflows/test-avd-28.yml
@@ -1,0 +1,12 @@
+name: daily-test-avd-28
+
+on:
+  push:
+    branches: [ test-all-avd ]
+
+jobs:
+  job1:
+    uses: ./.github/workflows/test-avd.yml
+    with:
+      api-level: 28
+      arch: x86_64

--- a/.github/workflows/test-avd-29.yml
+++ b/.github/workflows/test-avd-29.yml
@@ -1,0 +1,12 @@
+name: daily-test-avd-29
+
+on:
+  push:
+    branches: [ test-all-avd ]
+
+jobs:
+  job1:
+    uses: ./.github/workflows/test-avd.yml
+    with:
+      api-level: 29
+      arch: x86_64

--- a/.github/workflows/test-avd-30.yml
+++ b/.github/workflows/test-avd-30.yml
@@ -1,0 +1,12 @@
+name: daily-test-avd-30
+
+on:
+  push:
+    branches: [ test-all-avd ]
+
+jobs:
+  job1:
+    uses: ./.github/workflows/test-avd.yml
+    with:
+      api-level: 30
+      arch: x86_64

--- a/.github/workflows/test-avd-31.yml
+++ b/.github/workflows/test-avd-31.yml
@@ -1,0 +1,12 @@
+name: daily-test-avd-31
+
+on:
+  push:
+    branches: [ test-all-avd ]
+
+jobs:
+  job1:
+    uses: ./.github/workflows/test-avd.yml
+    with:
+      api-level: 31
+      arch: x86_64

--- a/.github/workflows/test-avd.yml
+++ b/.github/workflows/test-avd.yml
@@ -1,0 +1,54 @@
+name: AVD测试
+on:
+  workflow_call:
+    inputs:
+      api-level:
+        required: true
+        type: number
+      arch:
+        required: true
+        type: string
+
+jobs:
+  build-and-test-on-macos:
+    runs-on: macos-latest
+    env:
+      DISABLE_TENCENT_MAVEN_MIRROR: true
+    steps:
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v3.x
+      - name: checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'gradle'
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: revert gradle wrapper mirror setting
+        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
+      - name: buildSdk
+        run: ./gradlew buildSdk -S
+      - name: build sample/source
+        run: ./gradlew build
+      - name: unit test
+        run: ./gradlew jvmTestSdk -S
+      - name: run androidTestSdk
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ inputs.api-level }}
+          sdcard-path-or-size: 100M
+          emulator-build: 8420304
+          target: default
+          arch: ${{ inputs.arch }}
+          profile: pixel_2
+          script: ./gradlew androidTestSdk
+      - name: stop gradle deamon for actions/cache
+        run: ./gradlew --stop


### PR DESCRIPTION
测试时需要手工push分支。定时构建延迟太大，且成功率不高。