### PR TITLE
test: none-dynamic宿主打包插件依赖的被测试类

### DIFF
--- a/projects/test/none-dynamic/host/test-none-dynamic-host/build.gradle
+++ b/projects/test/none-dynamic/host/test-none-dynamic-host/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation 'com.tencent.shadow.core:activity-container'
     implementation project(':custom-view')
     implementation "androidx.test.espresso:espresso-idling-resource:$espresso_version"
+    implementation project(':plugin-use-host-code-lib')
 }
 
 def createCopyTask(projectName, buildType, name, apkName) {


### PR DESCRIPTION
对应TestHostInterfaceActivity测试用例。由于白名单没有包含`subpackage`子包，所以Foo类访问不到是正常的。

#982