### PR TITLE
fix(core.runtime): 去掉Application OnCreate时多余的一次BroadcastReceiver实例化

### DIFF
--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowApplication.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowApplication.java
@@ -92,9 +92,10 @@ public class ShadowApplication extends ShadowContext {
         for (Map.Entry<String, String[]> entry : mBroadcasts.entrySet()) {
             try {
                 String receiverClassname = entry.getKey();
-                Class<?> clazz = mPluginClassLoader.loadClass(receiverClassname);
-                BroadcastReceiver receiver = ((BroadcastReceiver) clazz.newInstance());
-                mAppComponentFactory.instantiateReceiver(mPluginClassLoader, receiverClassname, null);
+                BroadcastReceiver receiver = mAppComponentFactory.instantiateReceiver(
+                        mPluginClassLoader,
+                        receiverClassname,
+                        null);
 
                 IntentFilter intentFilter = new IntentFilter();
                 String[] receiverActions = entry.getValue();


### PR DESCRIPTION
并且插件Application OnCreate时构造静态广播BroadcastReceiver时应该由外部注入的AppComponentFactory构造。

fix #1034