### PR TITLE
fix(core.transform_kit): 读取jarInputs时忽略不会被编译的文件

### DIFF
--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransform.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransform.kt
@@ -23,7 +23,6 @@ import javassist.ClassPool
 import javassist.CtClass
 import org.gradle.api.Project
 import java.io.*
-import java.io.File
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import kotlin.system.measureTimeMillis
@@ -82,14 +81,6 @@ abstract class AbstractTransform(
     }
 
     private fun CtClass.debugWriteJar(outputEntryName: String?, outputStream: ZipOutputStream) {
-        //忽略META-INF
-        if (outputEntryName != null
-            && listOf<(String) -> Boolean>(
-                { it.startsWith("META-INF/") },
-                { it == "module-info.class" },
-            ).any { it(outputEntryName) }
-        ) return
-
         try {
             val entryName = outputEntryName ?: (name.replace('.', '/') + ".class")
             outputStream.putNextEntry(ZipEntry(entryName))


### PR DESCRIPTION
之前是debugWriteJar遇到重复的module-info.class，所以简单的在
debugWriteJar时忽略这些文件的写出。

这是次遇到`com.squareup.moshi:moshi:1.13.0`直接在META-INF里 放了普通的class文件。这些类实际上也不会进入dex。

因此应该直接在输入文件时就忽略这些类，不应该等到debugWriteJar时再处理。

fixup! 55283721
fix #1102