### PR TITLE
fix(core): ShadowWebView init时应避免调用子类setWebViewClient实现

### DIFF
--- a/projects/sample/source/sample-plugin/sample-app/src/main/java/com/tencent/shadow/sample/plugin/app/lib/usecases/webview/WebViewActivity.java
+++ b/projects/sample/source/sample-plugin/sample-app/src/main/java/com/tencent/shadow/sample/plugin/app/lib/usecases/webview/WebViewActivity.java
@@ -1,9 +1,12 @@
 package com.tencent.shadow.sample.plugin.app.lib.usecases.webview;
 
 import android.app.Activity;
+import android.content.Context;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 
 import com.tencent.shadow.sample.plugin.app.lib.gallery.cases.entity.UseCase;
 
@@ -29,10 +32,31 @@ public class WebViewActivity extends Activity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        WebView webView = new WebView(this);
+        WebView webView = new FooWebView(this);
         webView.getSettings().setJavaScriptEnabled(true);
         webView.loadUrl("file:///android_asset/web/test.html?t=" + Math.random());
 
         setContentView(webView);
     }
+}
+
+/**
+ * 复现
+ * https://github.com/Tencent/Shadow/issues/1175
+ */
+class FooWebView extends WebView {
+
+    public FooWebView(@NonNull Context context) {
+        super(context);
+    }
+
+    @Override
+    public void setWebViewClient(@NonNull WebViewClient client) {
+        FooWebViewClient fooWebViewClient = (FooWebViewClient) client;
+        super.setWebViewClient(fooWebViewClient);
+    }
+}
+
+class FooWebViewClient extends WebViewClient {
+
 }

--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowWebView.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/ShadowWebView.java
@@ -79,7 +79,7 @@ public class ShadowWebView extends WebView {
 
     private void init(Context context) {
         mContext = context;
-        setWebViewClient(new WebViewClient());
+        super.setWebViewClient(new WarpWebViewClient(new WebViewClient(), mContext));
     }
 
     @Override


### PR DESCRIPTION
note：init时调用setWebViewClient是为了应对业务代码从来没有调用setWebViewClient的场景。

fix #1175