### PR TITLE
fix(core.gradle-plugin): 兼容更高版本cmdline-tools中apkanalyzer文件名变更

### DIFF
--- a/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/ShadowPlugin.kt
+++ b/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/ShadowPlugin.kt
@@ -101,14 +101,19 @@ class ShadowPlugin : Plugin<Project> {
                 // 如果有多个版本，随机取第一个，因为只用decodeXml方法，预期不同版本没什么区别。
                 val apkanalyzerJarFile =
                     try {
-                        sdkDirectory.walk().filter { it.name.equals("apkanalyzer.jar") }
-                            .first()
+                        sdkDirectory.walk().filter { file ->
+                            listOf(
+                                "apkanalyzer.jar",// 低版本build tools
+                                "apkanalyzer-classpath.jar",// 2020-06-05 cmdline-tools version 2.0
+                            ).any { it == file.name }
+                        }.first()
                     } catch (e: NoSuchElementException) {
                         // https://developer.android.com/studio/command-line/apkanalyzer
                         // https://developer.android.com/studio/releases/sdk-tools
+                        // https://cs.android.com/android/platform/superproject/+/master:prebuilts/cmdline-tools/tools/bin/apkanalyzer;l=67;bpv=1;bpt=0
                         throw Error(
-                            "找不到apkanalyzer.jar.它来自：" +
-                                    "SDK Tools, Revision 26.1.1 (September 2017)，" +
+                            "找不到apkanalyzer.它来自：" +
+                                    "cmdline-tools." +
                                     "如果高版本SDK也找不到这个文件，Shadow就需要更新了。"
                         )
                     }


### PR DESCRIPTION
看起来只是在cmdline-tools 2.0版本升级中，把这些java lib的jar文件名都加了 -classpath后缀。

fix #1179

本地hardcode了commandlinetools-linux-9477386_latest.zip解压目录中的apkanalyzer-classpath.jar路径，
测试了decodeXml工作正常。