### PR TITLE
fix: 兼容AGP 7.4.1

### DIFF
--- a/buildScripts/gradle/maven.gradle
+++ b/buildScripts/gradle/maven.gradle
@@ -115,6 +115,7 @@ publishing {
                 def root = asNode()
                 def dependencies = root.appendNode('dependencies')
                 dependencies.append(getDependencyNode('compile', 'org.jetbrains.kotlin', 'kotlin-stdlib-jdk7', kotlin_version))
+                dependencies.append(getDependencyNode('compile', 'com.googlecode.json-simple', 'json-simple', json_simple_version))
                 dependencies.append(getDependencyNode('compile', coreGroupId, 'transform-kit', publicationVersion))
                 dependencies.append(getDependencyNode('compile', coreGroupId, 'transform', publicationVersion))
                 dependencies.append(getDependencyNode('compile', coreGroupId, 'runtime', publicationVersion))

--- a/projects/test/gradle-plugin-agp-compat-test/test.sh
+++ b/projects/test/gradle-plugin-agp-compat-test/test.sh
@@ -29,6 +29,8 @@ function testUnderAGPVersion() {
 
 # 测试版本来源
 # https://developer.android.com/studio/releases/gradle-plugin
+setGradleVersion 7.5
+testUnderAGPVersion 7.4.1
 setGradleVersion 7.4
 testUnderAGPVersion 7.3.1
 setGradleVersion 7.3.3


### PR DESCRIPTION
漏了在pom中声明json-simple的依赖。
升级AGP后没有传递来的依赖就找不到类了。