### PR TITLE
fix(core.manager): 修复deleteInstalledPlugin方法调用结果总是返回false

### DIFF
--- a/projects/sdk/core/manager/src/main/java/com/tencent/shadow/core/manager/BasePluginManager.java
+++ b/projects/sdk/core/manager/src/main/java/com/tencent/shadow/core/manager/BasePluginManager.java
@@ -355,20 +355,39 @@ public abstract class BasePluginManager {
 
     private boolean deletePart(InstalledPlugin.Part part) {
         boolean suc = true;
-        if (!part.pluginFile.delete()) {
+        if (!deleteFileOrDirectory(part.pluginFile)) {
             suc = false;
         }
-        if (part.oDexDir != null) {
-            if (!part.oDexDir.delete()) {
-                suc = false;
-            }
+        if (part.oDexDir != null && !deleteFileOrDirectory(part.oDexDir)) {
+            suc = false;
         }
-        if (part.libraryDir != null) {
-            if (!part.libraryDir.delete()) {
-                suc = false;
-            }
+        if (part.libraryDir != null && !deleteFileOrDirectory(part.libraryDir)) {
+            suc = false;
         }
         return suc;
+    }
+
+    /**
+     * 删除文件或目录,递归删除
+     *
+     * @param fileOrDirectory 文件或目录
+     * @return 是否删除成功
+     */
+    private boolean deleteFileOrDirectory(File fileOrDirectory) {
+        if (fileOrDirectory == null || !fileOrDirectory.exists()) {
+            return true;
+        }
+        if (fileOrDirectory.isDirectory()) {
+            File[] files = fileOrDirectory.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    if (!deleteFileOrDirectory(file)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return fileOrDirectory.delete();
     }
 
     /**


### PR DESCRIPTION
note：增加一个删除方法，如果有子目录则先删除子目录下的文件在删除自身，解决非空文件夹带来的删除失败问题

fix #1140