### PR TITLE
feat(core): 支持AGP 8.0+所需的新版Transform API

### DIFF
--- a/.github/workflows/pr-check-gradle-plugin.yml
+++ b/.github/workflows/pr-check-gradle-plugin.yml
@@ -30,13 +30,26 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: revert gradle wrapper mirror setting
-        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
+        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
       - name: revert gradle wrapper mirror setting
         working-directory: projects/test/gradle-plugin-agp-compat-test
-        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
-      - name: test AGP compatibility when core.gradle-plugin changed
+        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+      - name: test AGP compatibility when core.gradle-plugin changed with JDK17
         working-directory: projects/test/gradle-plugin-agp-compat-test
-        run: ./test.sh
+        run: ./test_JDK17.sh
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'gradle'
+      - name: test AGP compatibility when core.gradle-plugin changed with JDK11
+        working-directory: projects/test/gradle-plugin-agp-compat-test
+        run: ./test_JDK11.sh
 
       - name: stop gradle deamon for actions/cache
         run: ./gradlew --stop

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -23,10 +23,10 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
       - name: checkout
         uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'gradle'
       - uses: actions/cache@v2
         with:
@@ -37,7 +37,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: revert gradle wrapper mirror setting
-        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
+        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
       - name: buildSdk
         run: ./gradlew buildSdk -S
       - name: build sample/source
@@ -64,10 +64,10 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
       - name: checkout
         uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'gradle'
       - uses: actions/cache@v2
         with:
@@ -78,7 +78,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: revert gradle wrapper mirror setting
-        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
+        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
       - name: buildSdk
         run: ./gradlew buildSdk -S
       - name: build sample/source
@@ -103,7 +103,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: revert gradle wrapper mirror setting
-        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
+        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
       - name: revert gradle wrapper mirror setting for sample host-project
         working-directory: projects/sample/maven/host-project
         run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip' >  gradle/wrapper/gradle-wrapper.properties

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
       - name: checkout
         uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'gradle'
       - uses: actions/cache@v2
         with:
@@ -29,7 +29,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: revert gradle wrapper mirror setting
-        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
+        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
       - name: buildSdk
         run: ./gradlew buildSdk
       - name: build sample/source
@@ -59,10 +59,10 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
       - name: checkout
         uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'gradle'
       - uses: actions/cache@v2
         with:
@@ -73,7 +73,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: revert gradle wrapper mirror setting
-        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
+        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
       - name: publish
         run: ./gradlew publish
       - name: stop gradle deamon for actions/cache

--- a/.github/workflows/test-avd.yml
+++ b/.github/workflows/test-avd.yml
@@ -19,10 +19,10 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
       - name: checkout
         uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'gradle'
       - uses: actions/cache@v2
         with:
@@ -33,7 +33,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: revert gradle wrapper mirror setting
-        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
+        run: echo 'distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip' >  gradle/wrapper/gradle-wrapper.properties
       - name: buildSdk
         run: ./gradlew buildSdk -S
       - name: build sample/source

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,8 @@ buildscript {
         def versions_properties_path = 'buildScripts/gradle/versions.properties'
         def versions = new Properties()
         versions.load(file(versions_properties_path).newReader())
-        versions.forEach { key, value ->
+        versions.forEach { key, stringValue ->
+            def value = stringValue?.isInteger() ? stringValue as Integer : stringValue
             ext.set(key, value)
         }
     }

--- a/buildScripts/gradle/common.gradle
+++ b/buildScripts/gradle/common.gradle
@@ -8,25 +8,21 @@ def gitShortRev() {
 }
 
 allprojects {
-    ext.COMPILE_SDK_VERSION = 31
-    ext.MIN_SDK_VERSION = 14
-    ext.TARGET_SDK_VERSION = 28
-    ext.VERSION_CODE = 1
-
+    def versionName, versionSuffix
     if ("${System.env.CI}".equalsIgnoreCase("true")) {
-        ext.VERSION_NAME = System.getenv("GITHUB_REF_SLUG")
+        versionName = System.getenv("GITHUB_REF_SLUG")
     } else {
-        ext.VERSION_NAME = "local"
+        versionName = project.VERSION_NAME
     }
 
     if ("${System.env.PUBLISH_RELEASE}".equalsIgnoreCase("true")) {
-        ext.VERSION_SUFFIX = ""
+        versionSuffix = ""
     } else if ("${System.env.CI}".equalsIgnoreCase("true")) {
-        ext.VERSION_SUFFIX = "-${System.env.GITHUB_SHA_SHORT}-SNAPSHOT"
+        versionSuffix = "-${System.env.GITHUB_SHA_SHORT}-SNAPSHOT"
     } else {
-        ext.VERSION_SUFFIX = "-${gitShortRev()}-SNAPSHOT"
+        versionSuffix = "-${gitShortRev()}-SNAPSHOT"
     }
-    ext.ARTIFACT_VERSION = ext.VERSION_NAME + ext.VERSION_SUFFIX
+    ext.ARTIFACT_VERSION = versionName + versionSuffix
     ext.TEST_HOST_APP_APPLICATION_ID = 'com.tencent.shadow.test.hostapp'
     ext.SAMPLE_HOST_APP_APPLICATION_ID = 'com.tencent.shadow.sample.host'
     repositories {

--- a/buildScripts/gradle/versions.properties
+++ b/buildScripts/gradle/versions.properties
@@ -1,3 +1,8 @@
+COMPILE_SDK_VERSION=31
+MIN_SDK_VERSION=14
+TARGET_SDK_VERSION=28
+VERSION_CODE=1
+VERSION_NAME=local
 android_build_tools_version=30.0.3
 android_support_annotations_version=28.0.0
 android_support_version=27.1.1
@@ -5,7 +10,7 @@ androidx_activity_version=1.4.0
 androidx_appcompat_version=1.4.1
 androidx_test_junit_version=1.1.2
 androidx_test_version=1.3.0
-build_gradle_version=7.0.3
+build_gradle_version=7.4.2
 commons_io_android_version=2.5
 commons_io_jvm_version=2.9.0
 espresso_version=3.3.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-#distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
-distributionUrl=https\://mirrors.tencent.com/gradle/gradle-7.0.2-bin.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://mirrors.tencent.com/gradle/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/projects/sample/source/sample-plugin/third-party/pinnedheaderexpandablelistview/build.gradle
+++ b/projects/sample/source/sample-plugin/third-party/pinnedheaderexpandablelistview/build.gradle
@@ -5,12 +5,10 @@ android {
 
 
     defaultConfig {
-        //noinspection MinSdkTooLow
-        minSdkVersion 8
-        //noinspection ExpiredTargetSdkVersion
-        targetSdkVersion 15
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion project.MIN_SDK_VERSION
+        targetSdkVersion project.TARGET_SDK_VERSION
+        versionCode project.VERSION_CODE
+        versionName project.VERSION_NAME
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/projects/sample/source/sample-plugin/third-party/slidingmenu/build.gradle
+++ b/projects/sample/source/sample-plugin/third-party/slidingmenu/build.gradle
@@ -5,12 +5,10 @@ android {
 
 
     defaultConfig {
-        //noinspection MinSdkTooLow
-        minSdkVersion 5
-        //noinspection ExpiredTargetSdkVersion
-        targetSdkVersion 17
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion project.MIN_SDK_VERSION
+        targetSdkVersion project.TARGET_SDK_VERSION
+        versionCode project.VERSION_CODE
+        versionName project.VERSION_NAME
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/projects/sdk/coding/build.gradle
+++ b/projects/sdk/coding/build.gradle
@@ -8,7 +8,8 @@ buildscript {
         def versions_properties_path = '../../../buildScripts/gradle/versions.properties'
         def versions = new Properties()
         versions.load(file(versions_properties_path).newReader())
-        versions.forEach { key, value ->
+        versions.forEach { key, stringValue ->
+            def value = stringValue?.isInteger() ? stringValue as Integer : stringValue
             ext.set(key, value)
         }
     }

--- a/projects/sdk/coding/code-generator/build.gradle
+++ b/projects/sdk/coding/code-generator/build.gradle
@@ -9,3 +9,15 @@ dependencies {
     compileOnly project(':android-jar')
     testImplementation project(':android-jar')
 }
+
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.6"
+    }
+}
+
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "1.6"
+    }
+}

--- a/projects/sdk/coding/code-generator/src/main/kotlin/com/tencent/shadow/coding/code_generator/ActivityCodeGenerator.kt
+++ b/projects/sdk/coding/code-generator/src/main/kotlin/com/tencent/shadow/coding/code_generator/ActivityCodeGenerator.kt
@@ -10,7 +10,16 @@ import android.content.ComponentCallbacks2
 import android.view.ContextThemeWrapper
 import android.view.KeyEvent
 import android.view.Window
-import com.squareup.javapoet.*
+import com.squareup.javapoet.AnnotationSpec
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.CodeBlock
+import com.squareup.javapoet.JavaFile
+import com.squareup.javapoet.MethodSpec
+import com.squareup.javapoet.ParameterSpec
+import com.squareup.javapoet.TypeName
+import com.squareup.javapoet.TypeSpec
+import com.squareup.javapoet.TypeVariableName
+import com.tencent.shadow.core.runtime.NeighborClass
 import javassist.ClassMap
 import javassist.ClassPool
 import javassist.LoaderClassPath
@@ -82,7 +91,8 @@ class ActivityCodeGenerator {
                 val cl = Thread.currentThread().contextClassLoader
                 classPool.appendClassPath(LoaderClassPath(cl))
             }
-            classPool.makeClass("$RUNTIME_PACKAGE.ShadowApplication").toClass()
+            classPool.makeClass("$RUNTIME_PACKAGE.ShadowApplication")
+                .toClass(NeighborClass::class.java)
         }
 
         val ActivityClass = Activity::class.java
@@ -115,7 +125,7 @@ class ActivityCodeGenerator {
             }
 
             ctClass.replaceClassName(renameMap)
-            return ctClass.toClass()
+            return ctClass.toClass(NeighborClass::class.java)
         }
 
         fun getActivityMethods(clazz: Class<*>): List<Method> {

--- a/projects/sdk/coding/code-generator/src/main/kotlin/com/tencent/shadow/core/runtime/NeighborClass.kt
+++ b/projects/sdk/coding/code-generator/src/main/kotlin/com/tencent/shadow/core/runtime/NeighborClass.kt
@@ -1,0 +1,7 @@
+package com.tencent.shadow.core.runtime
+
+/**
+ * 为了兼容JDK 17和javassist
+ * https://github.com/jboss-javassist/javassist/issues/369
+ */
+class NeighborClass

--- a/projects/sdk/coding/get-android-jar/build.gradle
+++ b/projects/sdk/coding/get-android-jar/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion project.COMPILE_SDK_VERSION
 }
 
-def sdkPath = android.sdkComponents.getSdkDirectory().get().asFile.absolutePath
+def sdkPath = android.sdkDirectory
 def androidJarPath = new File(sdkPath, "platforms/${android.compileSdkVersion}/android.jar")
 
 if (!androidJarPath.exists()) {

--- a/projects/sdk/coding/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/sdk/coding/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-#distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
-distributionUrl=https\://mirrors.tencent.com/gradle/gradle-7.0.2-bin.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://mirrors.tencent.com/gradle/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/projects/sdk/core/build.gradle
+++ b/projects/sdk/core/build.gradle
@@ -8,7 +8,8 @@ buildscript {
         def versions_properties_path = '../../../buildScripts/gradle/versions.properties'
         def versions = new Properties()
         versions.load(file(versions_properties_path).newReader())
-        versions.forEach { key, value ->
+        versions.forEach { key, stringValue ->
+            def value = stringValue?.isInteger() ? stringValue as Integer : stringValue
             ext.set(key, value)
         }
     }

--- a/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/AGPCompat.kt
+++ b/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/AGPCompat.kt
@@ -33,4 +33,5 @@ internal interface AGPCompat {
     fun getProcessResourcesTask(output: BaseVariantOutput): Task
     fun getAaptAdditionalParameters(processResourcesTask: Task): List<String>
     fun getMinSdkVersion(pluginVariant: ApplicationVariant): Int
+    fun hasDeprecatedTransformApi(): Boolean
 }

--- a/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/AGPCompatImpl.kt
+++ b/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/AGPCompatImpl.kt
@@ -71,6 +71,20 @@ internal class AGPCompatImpl : AGPCompat {
         return mergedFlavor.minSdkVersion?.apiLevel ?: VersionCodes.BASE
     }
 
+    override fun hasDeprecatedTransformApi(): Boolean {
+        try {
+            val version = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+            val majorVersion = version.substringBefore('.', "0").toInt()
+            if (majorVersion >= 8) {
+                return false//能parse出来主版本号大于等于8，我们就认为旧版Transform API不可用了。
+            }
+        } catch (ignored: Error) {
+        }
+
+        //读取版本号失败，就推测是旧版本的AGP，就应该有旧版本的Transform API
+        return true
+    }
+
     companion object {
         fun getStringFromProperty(x: Any?): String {
             return when (x) {

--- a/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/ShadowPlugin.kt
+++ b/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/ShadowPlugin.kt
@@ -24,6 +24,7 @@ import com.android.build.gradle.api.ApplicationVariant
 import com.android.sdklib.AndroidVersion.VersionCodes
 import com.tencent.shadow.core.gradle.extensions.PackagePluginExtension
 import com.tencent.shadow.core.manifest_parser.generatePluginManifest
+import com.tencent.shadow.core.transform.DeprecatedTransformWrapper
 import com.tencent.shadow.core.transform.ShadowTransform
 import com.tencent.shadow.core.transform_kit.AndroidClassPoolBuilder
 import com.tencent.shadow.core.transform_kit.ClassPoolBuilder
@@ -51,11 +52,15 @@ class ShadowPlugin : Plugin<Project> {
 
         val shadowExtension = project.extensions.create("shadow", ShadowExtension::class.java)
         if (!project.hasProperty("disable_shadow_transform")) {
-            baseExtension.registerTransform(ShadowTransform(
-                project,
-                lateInitBuilder,
-                { shadowExtension.transformConfig.useHostContext }
-            ))
+            baseExtension.registerTransform(
+                DeprecatedTransformWrapper(project,
+                    ShadowTransform(
+                        project,
+                        lateInitBuilder,
+                        { shadowExtension.transformConfig.useHostContext }
+                    )
+                )
+            )
         }
 
         addFlavorForTransform(baseExtension)

--- a/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/build.gradle
+++ b/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/build.gradle
@@ -1,5 +1,14 @@
 buildscript {
-    ext.build_gradle_version = '7.0.3'
+    loadVersions:
+    {// 读取versions.properties到ext中，供项目中直接用变量引用版本号
+        def versions_properties_path = '../../../../../../../../buildScripts/gradle/versions.properties'
+        def versions = new Properties()
+        versions.load(file(versions_properties_path).newReader())
+        versions.forEach { key, stringValue ->
+            def value = stringValue?.isInteger() ? stringValue as Integer : stringValue
+            ext.set(key, value)
+        }
+    }
     repositories {
         if (!System.getenv().containsKey("DISABLE_TENCENT_MAVEN_MIRROR")) {
             maven { url 'https://mirrors.tencent.com/nexus/repository/maven-public/' }
@@ -18,11 +27,6 @@ plugins {
 }
 
 allprojects {
-    ext.COMPILE_SDK_VERSION = 29
-    ext.MIN_SDK_VERSION = 16
-    ext.TARGET_SDK_VERSION = 28
-    ext.VERSION_CODE = 1
-    ext.VERSION_NAME = "local"
     repositories {
         if (!System.getenv().containsKey("DISABLE_TENCENT_MAVEN_MIRROR")) {
             maven { url 'https://mirrors.tencent.com/nexus/repository/maven-public/' }

--- a/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/plugin1/build.gradle
+++ b/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/plugin1/build.gradle
@@ -1,5 +1,14 @@
 buildscript {
-    ext.build_gradle_version = '7.0.3'
+    loadVersions:
+    {// 读取versions.properties到ext中，供项目中直接用变量引用版本号
+        def versions_properties_path = '../../../../../../../../../buildScripts/gradle/versions.properties'
+        def versions = new Properties()
+        versions.load(file(versions_properties_path).newReader())
+        versions.forEach { key, stringValue ->
+            def value = stringValue?.isInteger() ? stringValue as Integer : stringValue
+            ext.set(key, value)
+        }
+    }
     repositories {
         if (!System.getenv().containsKey("DISABLE_TENCENT_MAVEN_MIRROR")) {
             maven { url 'https://mirrors.tencent.com/nexus/repository/maven-public/' }
@@ -19,11 +28,6 @@ plugins {
 }
 
 allprojects {
-    ext.COMPILE_SDK_VERSION = 29
-    ext.MIN_SDK_VERSION = 16
-    ext.TARGET_SDK_VERSION = 28
-    ext.VERSION_CODE = 1
-    ext.VERSION_NAME = "local"
     repositories {
         if (!System.getenv().containsKey("DISABLE_TENCENT_MAVEN_MIRROR")) {
             maven { url 'https://mirrors.tencent.com/nexus/repository/maven-public/' }

--- a/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/plugin2/build.gradle
+++ b/projects/sdk/core/gradle-plugin/src/test/testProjects/case1/plugin2/build.gradle
@@ -1,5 +1,14 @@
 buildscript {
-    ext.build_gradle_version = '7.0.3'
+    loadVersions:
+    {// 读取versions.properties到ext中，供项目中直接用变量引用版本号
+        def versions_properties_path = '../../../../../../../../../buildScripts/gradle/versions.properties'
+        def versions = new Properties()
+        versions.load(file(versions_properties_path).newReader())
+        versions.forEach { key, stringValue ->
+            def value = stringValue?.isInteger() ? stringValue as Integer : stringValue
+            ext.set(key, value)
+        }
+    }
     repositories {
         if (!System.getenv().containsKey("DISABLE_TENCENT_MAVEN_MIRROR")) {
             maven { url 'https://mirrors.tencent.com/nexus/repository/maven-public/' }
@@ -19,11 +28,6 @@ plugins {
 }
 
 allprojects {
-    ext.COMPILE_SDK_VERSION = 29
-    ext.MIN_SDK_VERSION = 16
-    ext.TARGET_SDK_VERSION = 28
-    ext.VERSION_CODE = 1
-    ext.VERSION_NAME = "local"
     repositories {
         if (!System.getenv().containsKey("DISABLE_TENCENT_MAVEN_MIRROR")) {
             maven { url 'https://mirrors.tencent.com/nexus/repository/maven-public/' }

--- a/projects/sdk/core/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/sdk/core/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-#distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
-distributionUrl=https\://mirrors.tencent.com/gradle/gradle-7.0.2-bin.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://mirrors.tencent.com/gradle/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/projects/sdk/core/transform-kit/build.gradle
+++ b/projects/sdk/core/transform-kit/build.gradle
@@ -22,6 +22,11 @@ compileTestKotlin {
     }
 }
 
+java {
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
+}
+
 task testJar(type: Jar, dependsOn: testClasses) {
     baseName = "test-${project.archivesBaseName}"
     from sourceSets.test.output

--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransformManager.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransformManager.kt
@@ -21,24 +21,19 @@ package com.tencent.shadow.core.transform_kit
 import javassist.ClassPool
 import javassist.CtClass
 
-abstract class AbstractTransformManager(
-    ctClassInputMap: Map<CtClass, InputClass>,
-    private val classPool: ClassPool
-) {
-    private val allInputClass = ctClassInputMap.keys
-
+abstract class AbstractTransformManager(private val classPool: ClassPool) {
     abstract val mTransformList: List<SpecificTransform>
 
-    fun setupAll() {
+    fun setupAll(allInputCtClass: Set<CtClass>) {
         mTransformList.forEach {
             it.mClassPool = classPool
-            it.setup(allInputClass)
+            it.setup(allInputCtClass)
         }
     }
 
-    fun fireAll() {
+    fun fireAll(allInputCtClass: Set<CtClass>) {
         mTransformList.flatMap { it.list }.forEach { transform ->
-            transform.filter(allInputClass).forEach {
+            transform.filter(allInputCtClass).forEach {
                 transform.transform(it)
             }
         }

--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/ClassTransform.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/ClassTransform.kt
@@ -19,279 +19,120 @@
 package com.tencent.shadow.core.transform_kit
 
 import com.android.SdkConstants
-import com.android.build.api.transform.*
-import com.android.build.api.transform.QualifiedContent.ContentType
-import com.android.build.api.transform.QualifiedContent.Scope
-import com.android.build.gradle.internal.pipeline.TransformManager
 import com.android.utils.FileUtils
-import com.google.common.collect.ImmutableList
-import com.google.common.io.Files
 import org.gradle.api.Project
 import java.io.File
 import java.io.FileInputStream
-import java.io.FileOutputStream
 import java.io.OutputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
-import java.util.zip.ZipOutputStream
 
 /**
  * 类转换基类
  *
  * @author cubershi
  */
-abstract class ClassTransform(val project: Project) : Transform() {
-    val inputSet: MutableSet<TransformInput> = mutableSetOf()
+abstract class ClassTransform(val project: Project) {
 
     /**
      * 获取输入文件对应的输出文件路径.即将文件this路径中的inputDir部分替换为outputDir.
      */
-    fun File.toOutputFile(inputDir: File, outputDir: File): File {
+    private fun File.toOutputFile(inputDir: File, outputDir: File): File {
         return File(outputDir, this.toRelativeString(inputDir))
     }
 
-    fun input(
-        inputs: Collection<com.android.build.api.transform.TransformInput>,
-        outputProvider: TransformOutputProvider
-    ) {
+    fun input(inputs: Iterable<TransformInput>) {
         val logger = project.logger
         if (logger.isInfoEnabled) {
             val sb = StringBuilder()
             sb.appendln()
             inputs.forEach {
-                it.directoryInputs.forEach {
-                    sb.appendln(it.file.absolutePath)
-                }
-                it.jarInputs.forEach {
-                    sb.appendln(it.file.absolutePath)
-                }
+                sb.appendln(it.asFile().absolutePath)
             }
             logger.info("ClassTransform input paths:$sb")
         }
 
-        inputs.forEach {
-            it.directoryInputs.forEach {
-                val inputDir = it.file
-                val transformInput = TransformInput(it)
-                inputSet.add(transformInput)
-                val allFiles = FileUtils.getAllFiles(it.file)
-                allFiles.filter {
-                    it?.name?.endsWith(SdkConstants.DOT_CLASS) ?: false
-                }.forEach {
-                    val inputClass = DirInputClass()
-                    inputClass.onInputClass(
-                        it,
-                        it.toOutputFile(inputDir, transformInput.toOutput(outputProvider))
-                    )
-                    transformInput.addInputClass(inputClass)
-                }
-            }
-
-            it.jarInputs.forEach {
-                val transformInput = TransformInput(it)
-                inputSet.add(transformInput)
-                ZipInputStream(FileInputStream(it.file)).use { zis ->
-                    var entry: ZipEntry?
-                    while (true) {
-                        entry = zis.nextEntry
-                        if (entry == null) break
-
-                        val name = entry.name
-
-                        // 忽略一些实际上不会进入编译classpath的文件
-                        if (entry.isDirectory) continue
-                        if (!name.endsWith(SdkConstants.DOT_CLASS)) continue
-                        if (name.startsWith("META-INF/", true)) continue
-                        if (name.endsWith("module-info.class", true)) continue
-                        if (name.endsWith("package-info.class", true)) continue
-
-                        // 记录好entry和name的关系，添加再添加成transform的输入
-                        val inputClass = JarInputClass()
-                        inputClass.onInputClass(zis, name)
-                        transformInput.addInputClass(inputClass)
+        inputs.forEach { transformInput ->
+            when (transformInput.kind) {
+                TransformInput.Kind.DIRECTORY -> {
+                    val inputDir = transformInput.asFile()
+                    val allFiles = FileUtils.getAllFiles(inputDir)
+                    allFiles.filter {
+                        it?.name?.endsWith(SdkConstants.DOT_CLASS) ?: false
+                    }.forEach {
+                        val className = loadDotClassFile(it)
+                        transformInput.inputClassNames.add(className)
                     }
                 }
-            }
-        }
-    }
 
-    fun output(outputProvider: TransformOutputProvider) {
-        inputSet.forEach { input ->
-            when (input.format) {
-                Format.DIRECTORY -> {
-                    input.getInputClass().forEach {
-                        val dirInputClass = it as DirInputClass
-                        dirInputClass.getOutput().forEach {
-                            val className = it.first
-                            val file = it.second
-                            Files.createParentDirs(file)
-                            FileOutputStream(file).use {
-                                onOutputClass(null, className, it)
-                            }
-                        }
-                    }
-                }
-                Format.JAR -> {
-                    val outputJar = input.toOutput(outputProvider)
-                    Files.createParentDirs(outputJar)
-                    ZipOutputStream(FileOutputStream(outputJar)).use { zos ->
-                        input.getInputClass().forEach {
-                            val jarInputClass = it as JarInputClass
-                            jarInputClass.getOutput().forEach {
-                                val className = it.first
-                                val entryName = it.second
-                                zos.putNextEntry(ZipEntry(entryName))
-                                onOutputClass(entryName, className, zos)
-                            }
+                TransformInput.Kind.JAR -> {
+                    ZipInputStream(FileInputStream(transformInput.asFile())).use { zis ->
+                        var entry: ZipEntry?
+                        while (true) {
+                            entry = zis.nextEntry
+                            if (entry == null) break
+
+                            val entryName = entry.name
+
+                            // 忽略一些实际上不会进入编译classpath的文件
+                            if (entry.isDirectory) continue
+                            if (!entryName.endsWith(SdkConstants.DOT_CLASS)) continue
+                            if (entryName.startsWith("META-INF/", true)) continue
+                            if (entryName.endsWith("module-info.class", true)) continue
+                            if (entryName.endsWith("package-info.class", true)) continue
+
+                            val className = loadClassFromJar(zis)
+                            transformInput.inputClassNames.add(className)
                         }
                     }
                 }
             }
         }
+
+
     }
 
-    abstract fun onOutputClass(entryName: String?, className: String, outputStream: OutputStream)
+    abstract fun onOutputClass(className: String, outputStream: OutputStream)
 
-    abstract fun DirInputClass.onInputClass(classFile: File, outputFile: File)
+    /**
+     * 让子类实现的字节码编辑框架加载.class文件，加载后返回类名
+     */
+    abstract fun loadDotClassFile(classFile: File): String
 
-    abstract fun JarInputClass.onInputClass(zipInputStream: ZipInputStream, entryName: String)
+    /**
+     * 让子类实现的字节码编辑框架加载jar中的class，加载后返回类名
+     */
+    abstract fun loadClassFromJar(zipInputStream: ZipInputStream): String
 
     abstract fun onTransform()
-
-    override fun getName(): String = this::class.simpleName!!
-
-    override fun getInputTypes(): MutableSet<ContentType> = TransformManager.CONTENT_CLASS
-
-    override fun isIncremental(): Boolean = false
-
-    override fun getScopes(): MutableSet<in Scope> = TransformManager.SCOPE_FULL_PROJECT
 
     /**
      * 每一次执行transform前调用。在一次构建中可能有多个Variant，多个Variant会共用同一个
      * Transform对象（就是这个类的对象）。在这里提供一个时机清理transform过程中产生的缓存，
      * 避免对下一次transform产生影响。
      */
-    open fun beforeTransform(invocation: TransformInvocation) {
-        invocation.outputProvider.deleteAll()
-        inputSet.clear()
+    open fun beforeTransform() {
     }
 
-    open fun afterTransform(invocation: TransformInvocation) {
-    }
-
-    final override fun transform(invocation: TransformInvocation) {
-        beforeTransform(invocation)
-        input(invocation.inputs, invocation.outputProvider)
-        onTransform()
-        output(invocation.outputProvider)
-        afterTransform(invocation)
-    }
-
-    override fun getSecondaryFiles(): ImmutableList<SecondaryFile>? {
-        val transformJar = File(this::class.java.protectionDomain.codeSource.location.toURI())
-        val transformKitJar =
-            File(ClassTransform::class.java.protectionDomain.codeSource.location.toURI())
-
-        return ImmutableList.of(
-            //将当前类运行所在的jar本身作为转换输入的SecondaryFiles，也就作为了这个transform task的inputs的
-            //一部分，这使得当这个Transform程序变化时，构建能检测到这个Transform需要重新执行。这是直接编辑这个
-            //Transform源码后，应用了这个Plugin的debug工程能直接生效的关键。
-            SecondaryFile.nonIncremental(project.files(transformJar)),
-            SecondaryFile.nonIncremental(project.files(transformKitJar))
-        )
-    }
-}
-typealias ClassName_OutputFile = Pair<String, File>
-typealias ClassName_EntryName = Pair<String, String>
-
-abstract class InputClass() {
-    abstract fun renameOutput(oldName: String, newName: String)
-}
-
-class DirInputClass() : InputClass() {
-    private val outputs = mutableMapOf<String, File>()
-    fun getOutput(): Set<ClassName_OutputFile> {
-        val mutableSet = mutableSetOf<ClassName_OutputFile>()
-        return outputs.mapTo(mutableSet) {
-            ClassName_OutputFile(it.key, it.value)
-        }
-    }
-
-    fun addOutput(className: String, file: File) {
-        outputs[className] = file
-    }
-
-    fun getOutput(className: String): File {
-        return outputs[className]!!
-    }
-
-    override fun renameOutput(oldName: String, newName: String) {
-        val file = outputs.remove(oldName)!!
-        val newFileName = file.name.replace(getSimpleName(oldName), getSimpleName(newName))
-        outputs[newName] = File(file.parent, newFileName)
-    }
-
-    private fun getSimpleName(name: String): String {
-        val i = name.lastIndexOf('.')
-        if (i == -1) {
-            return name
-        } else {
-            return name.substring(i + 1)
-        }
-    }
-}
-
-class JarInputClass() : InputClass() {
-    private val outputs = mutableMapOf<String, String>()
-    fun getOutput(): Set<ClassName_EntryName> {
-        val mutableSet = mutableSetOf<ClassName_EntryName>()
-        return outputs.mapTo(mutableSet) {
-            ClassName_EntryName(it.key, it.value)
-        }
-    }
-
-    fun addOutput(className: String, entryName: String) {
-        outputs[className] = entryName
-    }
-
-    fun getOutput(className: String): String {
-        return outputs[className]!!
-    }
-
-    override fun renameOutput(oldName: String, newName: String) {
-        outputs[newName] = newName.replace('.', '/') + ".class"
+    open fun afterTransform() {
     }
 
 }
 
+/**
+ * 输入数据的封装
+ * 外部Transform框架的适配器DeprecatedTransformWrapper或者GradleTransformWrapper
+ * 把它们的输入封装成这个抽象类的子类
+ */
+abstract class TransformInput {
+    /**
+     * 一个TransformInput可能是Dir包含多个class文件，也可能是一个jar包包含多个class文件。
+     * 这里把它们记下来，等输出的时候要按这个名单输出
+     */
+    val inputClassNames = mutableSetOf<String>()
 
-class TransformInput(
-    val name: String,
-    val contentTypes: Set<ContentType>,
-    val scopes: MutableSet<in Scope>,
-    val format: Format
-) {
-    constructor(di: DirectoryInput) : this(
-        di.name, di.contentTypes, di.scopes, Format.DIRECTORY
-    )
+    enum class Kind { DIRECTORY, JAR }
 
-    constructor(ji: JarInput) : this(
-        ji.name, ji.contentTypes, ji.scopes, Format.JAR
-    )
-
-    private val inputClassSet = mutableSetOf<InputClass>()
-
-    fun addInputClass(inputClass: InputClass) {
-        inputClassSet.add(inputClass)
-    }
-
-    fun getInputClass() = inputClassSet.toSet()
-
-    fun toOutput(outputProvider: TransformOutputProvider) =
-        outputProvider.getContentLocation(
-            name,
-            contentTypes,
-            scopes,
-            format
-        )
+    abstract val kind: Kind
+    abstract fun asFile(): File
 }

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/DeprecatedTransformWrapper.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/DeprecatedTransformWrapper.kt
@@ -1,0 +1,157 @@
+@file:Suppress("DEPRECATION")
+
+package com.tencent.shadow.core.transform
+
+import com.android.build.api.transform.DirectoryInput
+import com.android.build.api.transform.Format
+import com.android.build.api.transform.JarInput
+import com.android.build.api.transform.QualifiedContent
+import com.android.build.api.transform.SecondaryFile
+import com.android.build.api.transform.Transform
+import com.android.build.api.transform.TransformInvocation
+import com.android.build.api.transform.TransformOutputProvider
+import com.android.build.api.variant.VariantInfo
+import com.android.build.gradle.internal.pipeline.TransformManager
+import com.google.common.collect.ImmutableList
+import com.google.common.io.Files
+import com.tencent.shadow.core.transform_kit.ClassTransform
+import com.tencent.shadow.core.transform_kit.TransformInput
+import org.gradle.api.Project
+import java.io.File
+import java.io.FileOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * 适配ClassTransform到AGP 8之前的Transform API
+ * 这是最初开发的、长期使用的比较稳定的实现。因为AGP 8去掉了这个API，所以不得不做两种适配。
+ */
+class DeprecatedTransformWrapper(
+    val project: Project, val classTransform: ClassTransform
+) : Transform() {
+    override fun getName(): String = "ShadowTransform"
+
+    override fun getInputTypes(): MutableSet<QualifiedContent.ContentType> =
+        TransformManager.CONTENT_CLASS
+
+    override fun isIncremental(): Boolean = false
+
+    override fun isCacheable(): Boolean {
+        return true
+    }
+
+    override fun applyToVariant(variant: VariantInfo): Boolean {
+        return if (variant.isTest) false
+        else variant.flavorNames.contains(ShadowTransform.ApplyShadowTransformFlavorName)
+    }
+
+    override fun getScopes(): MutableSet<in QualifiedContent.Scope> =
+        TransformManager.SCOPE_FULL_PROJECT
+
+    override fun transform(invocation: TransformInvocation) {
+        //before Transform clean output
+        val outputProvider = invocation.outputProvider
+        outputProvider.deleteAll()
+
+        val inputs: List<TransformInput> = invocation.inputs.flatMap { transformInput ->
+            transformInput.directoryInputs.map {
+                TransformInputImpl(it)
+            } + transformInput.jarInputs.map {
+                TransformInputImpl(it)
+            }
+        }
+
+        classTransform.beforeTransform()
+        classTransform.input(inputs)
+        classTransform.onTransform()
+        output(inputs, outputProvider)
+        classTransform.afterTransform()
+    }
+
+    /**
+     * 这个旧版Transform API需要把DIR里的class和jar里的class分别输出到DIR和对应的jar里，
+     * 这个行为是API决定的，不是通用的，因此要写在这里。对于ClassTransform来说，唯一可以复用的
+     * 就是把class输出到OutputStream中。
+     */
+    private fun output(inputs: Iterable<TransformInput>, outputProvider: TransformOutputProvider) {
+        inputs.forEach { transformInput ->
+            transformInput as TransformInputImpl
+
+            val outputLocation = outputProvider.getContentLocation(
+                transformInput.name,
+                transformInput.contentTypes,
+                transformInput.scopes,
+                transformInput.format
+            )
+
+            when (transformInput.kind) {
+                TransformInput.Kind.DIRECTORY -> {
+                    transformInput.inputClassNames.forEach { className ->
+                        val relativePath = className.replace('.', File.separatorChar) + ".class"
+                        val outputClassFile = File(outputLocation, relativePath)
+                        Files.createParentDirs(outputClassFile)
+                        FileOutputStream(outputClassFile).use {
+                            classTransform.onOutputClass(className, it)
+                        }
+                    }
+                }
+
+                TransformInput.Kind.JAR -> {
+                    Files.createParentDirs(outputLocation)
+                    ZipOutputStream(FileOutputStream(outputLocation)).use { zos ->
+                        transformInput.inputClassNames.forEach { className ->
+                            val entryName = className.replace('.', '/') + ".class"
+                            zos.putNextEntry(ZipEntry(entryName))
+                            classTransform.onOutputClass(className, zos)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+    override fun getSecondaryFiles(): ImmutableList<SecondaryFile>? {
+        val transformJar = File(this::class.java.protectionDomain.codeSource.location.toURI())
+        val transformKitJar =
+            File(ClassTransform::class.java.protectionDomain.codeSource.location.toURI())
+
+        return ImmutableList.of(
+            //将当前类运行所在的jar本身作为转换输入的SecondaryFiles，也就作为了这个transform task的inputs的
+            //一部分，这使得当这个Transform程序变化时，构建能检测到这个Transform需要重新执行。这是直接编辑这个
+            //Transform源码后，应用了这个Plugin的debug工程能直接生效的关键。
+            SecondaryFile.nonIncremental(project.files(transformJar)),
+            SecondaryFile.nonIncremental(project.files(transformKitJar))
+        )
+    }
+
+    private class TransformInputImpl(
+        val file: File,
+        val name: String,
+        val contentTypes: Set<QualifiedContent.ContentType>,
+        val scopes: MutableSet<in QualifiedContent.Scope>,
+        val format: Format,
+        override val kind: Kind,
+    ) : TransformInput() {
+        constructor(di: DirectoryInput) : this(
+            di.file,
+            di.name,
+            di.contentTypes,
+            di.scopes,
+            Format.DIRECTORY,
+            Kind.DIRECTORY
+        )
+
+        constructor(ji: JarInput) : this(
+            ji.file,
+            ji.name,
+            ji.contentTypes,
+            ji.scopes,
+            Format.JAR,
+            Kind.JAR
+        )
+
+        override fun asFile(): File = file
+
+    }
+}

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/GradleTransformWrapper.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/GradleTransformWrapper.kt
@@ -1,0 +1,80 @@
+package com.tencent.shadow.core.transform
+
+import com.tencent.shadow.core.transform_kit.ClassTransform
+import com.tencent.shadow.core.transform_kit.TransformInput
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.util.jar.JarOutputStream
+import java.util.zip.ZipEntry
+import javax.inject.Inject
+
+/**
+ * 适配AGP 7.2引入的新的Transform API，AGP没给这个API特别命名，但我们知道它是Gradle直接提供的Transform
+ * 接口。与之对应的是DeprecatedTransformWrapper适配旧的Transform API接口。
+ */
+abstract class GradleTransformWrapper @Inject constructor(@Internal val classTransform: ClassTransform) :
+    DefaultTask() {
+    // This property will be set to all Jar files available in scope
+    @get:InputFiles
+    abstract val allJars: ListProperty<RegularFile>
+
+    // Gradle will set this property with all class directories that available in scope
+    @get:InputFiles
+    abstract val allDirectories: ListProperty<Directory>
+
+    // Task will put all classes from directories and jars after optional modification into single jar
+    @get:OutputFile
+    abstract val output: RegularFileProperty
+
+    @TaskAction
+    fun taskAction() {
+        val inputs: List<TransformInput> = allDirectories.get().map {
+            TransformInputImpl(it.asFile, TransformInput.Kind.DIRECTORY)
+        } + allJars.get().map {
+            TransformInputImpl(it.asFile, TransformInput.Kind.JAR)
+        }
+
+        classTransform.beforeTransform()
+        classTransform.input(inputs)
+        classTransform.onTransform()
+        output(inputs)
+        classTransform.afterTransform()
+    }
+
+    private fun output(inputs: Iterable<TransformInput>) {
+        val jarOutput = JarOutputStream(
+            BufferedOutputStream(FileOutputStream(output.get().asFile))
+        )
+        jarOutput.use {
+            val outputClassNames = inputs.flatMap {
+                it.inputClassNames
+            }
+
+            outputClassNames.forEach { className ->
+                val entryName = className.replace('.', '/') + ".class"
+                jarOutput.putNextEntry(ZipEntry(entryName))
+                classTransform.onOutputClass(className, jarOutput)
+            }
+        }
+    }
+
+    private class TransformInputImpl(
+        val file: File,
+        override val kind: Kind
+    ) : TransformInput() {
+
+        override fun asFile(): File = file
+
+    }
+}
+

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/ShadowTransform.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/ShadowTransform.kt
@@ -18,8 +18,6 @@
 
 package com.tencent.shadow.core.transform
 
-import com.android.build.api.transform.TransformInvocation
-import com.android.build.api.variant.VariantInfo
 import com.tencent.shadow.core.transform_kit.AbstractTransform
 import com.tencent.shadow.core.transform_kit.AbstractTransformManager
 import com.tencent.shadow.core.transform_kit.ClassPoolBuilder
@@ -43,20 +41,10 @@ class ShadowTransform(
     override val mTransformManager: AbstractTransformManager
         get() = _mTransformManager
 
-    override fun beforeTransform(invocation: TransformInvocation) {
-        super.beforeTransform(invocation)
-        _mTransformManager = TransformManager(mCtClassInputMap, classPool, useHostContext)
+    override fun beforeTransform() {
+        super.beforeTransform()
+        _mTransformManager = TransformManager(classPool, useHostContext)
         classPool.makeInterface(SelfClassNamePlaceholder)
     }
 
-    override fun isCacheable(): Boolean {
-        return true
-    }
-
-    override fun getName(): String = "ShadowTransform"
-
-    override fun applyToVariant(variant: VariantInfo): Boolean {
-        return if (variant.isTest) false
-        else variant.flavorNames.contains(ApplyShadowTransformFlavorName)
-    }
 }

--- a/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/TransformManager.kt
+++ b/projects/sdk/core/transform/src/main/kotlin/com/tencent/shadow/core/transform/TransformManager.kt
@@ -18,18 +18,30 @@
 
 package com.tencent.shadow.core.transform
 
-import com.tencent.shadow.core.transform.specific.*
+import com.tencent.shadow.core.transform.specific.ActivityOptionsSupportTransform
+import com.tencent.shadow.core.transform.specific.ActivityTransform
+import com.tencent.shadow.core.transform.specific.AppComponentFactoryTransform
+import com.tencent.shadow.core.transform.specific.ApplicationTransform
+import com.tencent.shadow.core.transform.specific.ContentProviderTransform
+import com.tencent.shadow.core.transform.specific.DialogSupportTransform
+import com.tencent.shadow.core.transform.specific.FragmentSupportTransform
+import com.tencent.shadow.core.transform.specific.InstrumentationTransform
+import com.tencent.shadow.core.transform.specific.IntentServiceTransform
+import com.tencent.shadow.core.transform.specific.KeepHostContextTransform
+import com.tencent.shadow.core.transform.specific.LayoutInflaterTransform
+import com.tencent.shadow.core.transform.specific.PackageItemInfoTransform
+import com.tencent.shadow.core.transform.specific.PackageManagerTransform
+import com.tencent.shadow.core.transform.specific.ReceiverSupportTransform
+import com.tencent.shadow.core.transform.specific.ServiceTransform
+import com.tencent.shadow.core.transform.specific.WebViewTransform
 import com.tencent.shadow.core.transform_kit.AbstractTransformManager
-import com.tencent.shadow.core.transform_kit.InputClass
 import com.tencent.shadow.core.transform_kit.SpecificTransform
 import javassist.ClassPool
-import javassist.CtClass
 
 class TransformManager(
-    ctClassInputMap: Map<CtClass, InputClass>,
     classPool: ClassPool,
     useHostContext: () -> Array<String>
-) : AbstractTransformManager(ctClassInputMap, classPool) {
+) : AbstractTransformManager(classPool) {
 
     /**
      * 按这个列表的顺序应用各子Transform逻辑。

--- a/projects/sdk/core/transform/src/test/kotlin/com/tencent/shadow/core/transform/specific/ReceiverSupportTransformTest.kt
+++ b/projects/sdk/core/transform/src/test/kotlin/com/tencent/shadow/core/transform/specific/ReceiverSupportTransformTest.kt
@@ -43,7 +43,16 @@ class ReceiverSupportTransformTest : AbstractTransformTest() {
         val ctClass = dLoader[testClassName]
         val loader = Loader(this.javaClass.classLoader, dLoader)
         loader.delegateLoadingOf("android.content.")
-        val clazz = ctClass.toClass(loader)
+        val clazz = try {
+            loader.loadClass(testClassName)
+        } catch (e: ClassNotFoundException) {
+            ctClass.classPool.toClass(
+                ctClass,
+                test.TestActivity::class.java,
+                loader,
+                test.TestActivity::class.java.protectionDomain
+            )
+        }
 
         //构造实例，调用onReceive方法，检查log记录的字符串List是否符合预期
         val constructor = clazz.getDeclaredConstructor(List::class.java)

--- a/projects/sdk/dynamic/build.gradle
+++ b/projects/sdk/dynamic/build.gradle
@@ -8,7 +8,8 @@ buildscript {
         def versions_properties_path = '../../../buildScripts/gradle/versions.properties'
         def versions = new Properties()
         versions.load(file(versions_properties_path).newReader())
-        versions.forEach { key, value ->
+        versions.forEach { key, stringValue ->
+            def value = stringValue?.isInteger() ? stringValue as Integer : stringValue
             ext.set(key, value)
         }
     }

--- a/projects/sdk/dynamic/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/sdk/dynamic/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-#distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
-distributionUrl=https\://mirrors.tencent.com/gradle/gradle-7.0.2-bin.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://mirrors.tencent.com/gradle/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/projects/test/gradle-plugin-agp-compat-test/README.md
+++ b/projects/test/gradle-plugin-agp-compat-test/README.md
@@ -2,9 +2,13 @@
 
 准备一个桩工程`stub-project`，通过命令行参数控制其AGP版本和Shadow版本。
 
-自动化测试脚本: `test.sh`。其中先编译Shadow，发布到本地Maven，然后用这个Shadow版本进行测试。
+自动化测试脚本: `test_JDK11.sh`和`test_JDK17.sh`。其中先编译Shadow，发布到本地Maven，然后用这个Shadow版本进行测试。
 
 注意脚本会echo出执行的命令，如果遇到测试失败，可复制命令手工重新执行。
+
+`test_JDK11.sh`需要JDK 11环境，`test_JDK17.sh`需要JDK 17环境。
+
+`test_clean.sh`可以还原测试脚本对Gradle文件对改动。
 
 ### 确定实际使用的AGP版本：
 

--- a/projects/test/gradle-plugin-agp-compat-test/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/test/gradle-plugin-agp-compat-test/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-#distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
-distributionUrl=https\://mirrors.tencent.com/gradle/gradle-7.0.2-bin.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://mirrors.tencent.com/gradle/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/projects/test/gradle-plugin-agp-compat-test/stub-project/build.gradle
+++ b/projects/test/gradle-plugin-agp-compat-test/stub-project/build.gradle
@@ -41,6 +41,12 @@ allprojects {
 ext.disable_shadow_transform = true
 
 android {
+    try {
+        namespace 'app'
+    } catch (Exception ignored) {
+        // AGP 8之前找不到namespace这个方法的，不用设置。
+    }
+
     compileSdkVersion COMPILE_SDK_VERSION
 
     defaultConfig {

--- a/projects/test/gradle-plugin-agp-compat-test/stub-project/build.gradle
+++ b/projects/test/gradle-plugin-agp-compat-test/stub-project/build.gradle
@@ -1,4 +1,14 @@
 buildscript {
+    loadVersions:
+    {// 读取versions.properties到ext中，供项目中直接用变量引用版本号
+        def versions_properties_path = '../../../../buildScripts/gradle/versions.properties'
+        def versions = new Properties()
+        versions.load(file(versions_properties_path).newReader())
+        versions.forEach { key, stringValue ->
+            def value = stringValue?.isInteger() ? stringValue as Integer : stringValue
+            ext.set(key, value)
+        }
+    }
     repositories {
         if (!System.getenv().containsKey("DISABLE_TENCENT_MAVEN_MIRROR")) {
             maven { url 'https://mirrors.tencent.com/nexus/repository/maven-public/' }
@@ -18,11 +28,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.tencent.shadow.plugin'
 
 allprojects {
-    ext.COMPILE_SDK_VERSION = 29
-    ext.MIN_SDK_VERSION = 16
-    ext.TARGET_SDK_VERSION = 28
-    ext.VERSION_CODE = 1
-    ext.VERSION_NAME = "local"
     repositories {
         if (!System.getenv().containsKey("DISABLE_TENCENT_MAVEN_MIRROR")) {
             maven { url 'https://mirrors.tencent.com/nexus/repository/maven-public/' }

--- a/projects/test/gradle-plugin-agp-compat-test/test_JDK11.sh
+++ b/projects/test/gradle-plugin-agp-compat-test/test_JDK11.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Shadow工程因需要支持更高版本AGP，本身也需要用更高版本AGP构建。从AGP 8开始要求用JDK 17了。
+# 但使用Shadow的工程应该可以使用JDK 11。此脚本需要在JDK 11下测试低版本AGP工程的兼容性。
+
+JAVA_MAJOR_VERSION=$(javap -verbose java.lang.Object | grep "major version" | cut -d " " -f5)
+if [[ $JAVA_MAJOR_VERSION -ne 55 ]]; then
+  echo "需要JDK 11!"
+  exit 1
+fi
+
+source ./test_prepare.sh
+
+# 测试版本来源
+# AGP release页面：https://developer.android.com/studio/releases/gradle-plugin
+# AGP Maven仓库：https://mvnrepository.com/artifact/com.android.tools.build/gradle
+# Gradle下载：https://services.gradle.org/distributions/
+setGradleVersion 7.5
+testUnderAGPVersion 7.4.1
+setGradleVersion 7.4
+testUnderAGPVersion 7.3.1
+setGradleVersion 7.3.3
+testUnderAGPVersion 7.2.2
+setGradleVersion 7.2
+testUnderAGPVersion 7.1.1
+setGradleVersion 7.0.2
+testUnderAGPVersion 7.0.0
+testUnderAGPVersion 4.2.0
+testUnderAGPVersion 4.1.0
+setGradleVersion 6.1.1
+testUnderAGPVersion 4.0.0
+setGradleVersion 5.6.4
+testUnderAGPVersion 3.6.0
+setGradleVersion 5.4.1
+testUnderAGPVersion 3.5.0
+testUnderAGPVersion 3.4.0
+testUnderAGPVersion 3.3.0
+testUnderAGPVersion 3.2.0
+
+# 3.1.0在配合aapt2使用--package-id选项时不能设置小于0x7f的值，因此不再支持
+#testUnderAGPVersion 3.1.0
+
+#更低的版本支持成本过高

--- a/projects/test/gradle-plugin-agp-compat-test/test_JDK17.sh
+++ b/projects/test/gradle-plugin-agp-compat-test/test_JDK17.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# 从Gradle 7.5和AGP 8.0开始支持和要求使用JDK 17，所以这个脚本中的待测版本需要在JDK 17环境下测试。
+
+JAVA_MAJOR_VERSION=$(javap -verbose java.lang.Object | grep "major version" | cut -d " " -f5)
+if [[ $JAVA_MAJOR_VERSION -ne 61 ]]; then
+  echo "需要JDK 17!"
+  exit 1
+fi
+
+source ./test_prepare.sh
+
+# 测试版本来源
+# AGP release页面：https://developer.android.com/studio/releases/gradle-plugin
+# AGP Maven仓库：https://mvnrepository.com/artifact/com.android.tools.build/gradle
+# Gradle下载：https://services.gradle.org/distributions/
+setGradleVersion 7.5.1
+testUnderAGPVersion 7.4.1

--- a/projects/test/gradle-plugin-agp-compat-test/test_JDK17.sh
+++ b/projects/test/gradle-plugin-agp-compat-test/test_JDK17.sh
@@ -14,5 +14,12 @@ source ./test_prepare.sh
 # AGP release页面：https://developer.android.com/studio/releases/gradle-plugin
 # AGP Maven仓库：https://mvnrepository.com/artifact/com.android.tools.build/gradle
 # Gradle下载：https://services.gradle.org/distributions/
+setGradleVersion 8.4
+testUnderAGPVersion 8.3.0-alpha16
+setGradleVersion 8.2.1
+testUnderAGPVersion 8.2.0
+setGradleVersion 8.0.2
+testUnderAGPVersion 8.1.4
+testUnderAGPVersion 8.0.2
 setGradleVersion 7.5.1
 testUnderAGPVersion 7.4.1

--- a/projects/test/gradle-plugin-agp-compat-test/test_clean.sh
+++ b/projects/test/gradle-plugin-agp-compat-test/test_clean.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+git restore gradle/wrapper gradlew gradlew.bat
+git clean -fdx .

--- a/projects/test/gradle-plugin-agp-compat-test/test_prepare.sh
+++ b/projects/test/gradle-plugin-agp-compat-test/test_prepare.sh
@@ -26,32 +26,3 @@ function testUnderAGPVersion() {
   echo ./gradlew -PSetGradleVersion=false -PTestAGPVersion=$TestAGPVersion -PShadowVersion=$ShadowVersion :stub-project:assemblePluginA1B2Debug
   ./gradlew -PSetGradleVersion=false -PTestAGPVersion=$TestAGPVersion -PShadowVersion=$ShadowVersion :stub-project:assemblePluginA1B2Debug
 }
-
-# 测试版本来源
-# https://developer.android.com/studio/releases/gradle-plugin
-setGradleVersion 7.5
-testUnderAGPVersion 7.4.1
-setGradleVersion 7.4
-testUnderAGPVersion 7.3.1
-setGradleVersion 7.3.3
-testUnderAGPVersion 7.2.2
-setGradleVersion 7.2
-testUnderAGPVersion 7.1.1
-setGradleVersion 7.0.2
-testUnderAGPVersion 7.0.0
-testUnderAGPVersion 4.2.0
-testUnderAGPVersion 4.1.0
-setGradleVersion 6.1.1
-testUnderAGPVersion 4.0.0
-setGradleVersion 5.6.4
-testUnderAGPVersion 3.6.0
-setGradleVersion 5.4.1
-testUnderAGPVersion 3.5.0
-testUnderAGPVersion 3.4.0
-testUnderAGPVersion 3.3.0
-testUnderAGPVersion 3.2.0
-
-# 3.1.0在配合aapt2使用--package-id选项时不能设置小于0x7f的值，因此不再支持
-#testUnderAGPVersion 3.1.0
-
-#更低的版本支持成本过高


### PR DESCRIPTION
分3个提交来支持AGP 8.0+。
1. 升级自身构建环境到支持新版API的AGP 4.7.2。这个AGP版本同时可以使用新旧两套API。
2. 重构简化原有代码，给支持新API提供便利。
3. 支持新版API，加上自动化测试。

resolve #1212
