### PR TITLE
修复 createPackagePluginTask 任务在 Gradle 7.5 以后版本上添加失败和插件中 context.getDatabasePath(name) 方法当 name 传入全路径时运行异常的问题的问题

### DIFF
--- a/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/SubDirContextThemeWrapper.java
+++ b/projects/sdk/core/runtime/src/main/java/com/tencent/shadow/core/runtime/SubDirContextThemeWrapper.java
@@ -336,7 +336,10 @@ abstract class SubDirContextThemeWrapper extends ContextThemeWrapper {
     }
 
     private String makeSubName(String name) {
-        return getSubDirName() + "_" + name;
+        if (name.indexOf(File.separatorChar) < 0) {
+            return getSubDirName() + "_" + name;
+        }
+        return name;
     }
 
     private static File ensurePrivateDirExists(File dir) {


### PR DESCRIPTION
#1306 修复 Gradle 版本过高相关方法删除导致的插件打包任务添加错误
#1049 修复插件中 context.getDatabasePath(name) 方法当 name 传入全路径时运行异常的问题