### PR TITLE
fix(core.gradle-plugin): 替换在AGP 8.0+中被去掉的接口调用

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,17 @@ Shadow的所有代码都位于`projects`目录下的3个目录，分别是：
 其中`sample`应该是大家体验Shadow的最佳环境。
 详见`sample`目录中的[README](projects/sample/README.md)介绍。
 
+### 兼容性
+
+Shadow项目有较为完善的自动化测试，因此最新代码对外部环境的版本兼容性可以参考自动化测试的配置。
+
+* [pr-check.yml](.github/workflows/pr-check.yml) 虚拟机自动化测试，包含Android测试机版本和编译环境JDK等版本。
+* [pr-check-gradle-plugin.yml](.github/workflows/pr-check-gradle-plugin.yml) AGP兼容性测试。
+  其中指向的[test_JDK17.sh](projects/test/gradle-plugin-agp-compat-test/test_JDK17.sh)和
+  [test_JDK11.sh](projects/test/gradle-plugin-agp-compat-test/test_JDK11.sh)中定义了被测试的AGP版本。
+
 ## 自己写的测试代码出错？
+
 以我们多年的插件环境下业务开发经验，插件框架是不可能一步到位实现完美的。
 因此，我们相信大部分业务在接入时都是需要一定的二次开发工作。
 Shadow现有的代码满足的是我们自己的业务现在的需求。得益于全动态的设计，

--- a/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/CreatePackagePluginTask.kt
+++ b/projects/sdk/core/gradle-plugin/src/main/kotlin/com/tencent/shadow/core/gradle/CreatePackagePluginTask.kt
@@ -76,13 +76,18 @@ internal fun createPackagePluginTask(project: Project, buildType: PluginBuildTyp
 
         val suffix = if (extension.archiveSuffix.isEmpty()) "" else extension.archiveSuffix
         val prefix = if (extension.archivePrefix.isEmpty()) "plugin" else extension.archivePrefix
-        if (suffix.isEmpty()) {
-            it.archiveName = "$prefix-${buildType.name}.zip"
-        } else {
-            it.archiveName = "$prefix-${buildType.name}-$suffix.zip"
-        }
-        it.destinationDir =
+
+        val name =
+            if (suffix.isEmpty()) {
+                "$prefix-${buildType.name}.zip"
+            } else {
+                "$prefix-${buildType.name}-$suffix.zip"
+            }
+        it.archiveFileName.set(name)
+
+        it.destinationDirectory.set(
             File(if (extension.destinationDir.isEmpty()) "${project.rootDir}/build" else extension.destinationDir)
+        )
     }.dependsOn(createGenerateConfigTask(project, buildType))
 }
 

--- a/projects/test/gradle-plugin-agp-compat-test/stub-project/build.gradle
+++ b/projects/test/gradle-plugin-agp-compat-test/stub-project/build.gradle
@@ -75,6 +75,48 @@ android {
     }
 }
 
+// 创建两个假的apk，用于验证打包流程（packagePlugin）
+afterEvaluate {
+    tasks.getByPath(":stub-project:assemblePluginA1B2Debug").doLast {
+        File loader = project.file("build/outputs/apk/plugina1b2debug/loader.apk")
+        File runtime = project.file("build/outputs/apk/plugina1b2debug/runtime.apk")
+        loader.parentFile.mkdirs()
+        loader.createNewFile()
+        runtime.createNewFile()
+    }
+}
+
+shadow {
+    packagePlugin {
+        pluginTypes {
+            A1B2Debug {
+                loaderApkConfig = new Tuple2('loader.apk', ':stub-project:assemblePluginA1B2Debug')
+                runtimeApkConfig = new Tuple2('runtime.apk', ':stub-project:assemblePluginA1B2Debug')
+                pluginApks {
+                    pluginApk1 {
+                        businessName = 'stub-project'
+                        partKey = 'stub-project'
+                        buildTask = ':stub-project:assemblePluginA1B2Debug'
+                        apkPath = 'stub-project/build/outputs/apk/pluginA1B2/debug/stub-project-plugin-A1-B2-debug.apk'
+                        dependsOn = ['Core', 'Base']
+                        hostWhiteList = ["androidx.test.espresso",
+                                         "com.tencent.shadow.test.lib.plugin_use_host_code_lib.interfaces"]
+                    }
+                }
+            }
+        }
+
+        loaderApkProjectPath = 'stub-project'
+
+        runtimeApkProjectPath = 'stub-project'
+
+        uuid = '1234567890'
+        version = 4
+        compactVersion = [1, 2, 3]
+        uuidNickName = "1.1.5"
+    }
+}
+
 dependencies {
     //Shadow Transform后业务代码会有一部分实际引用runtime中的类
     //如果不以compileOnly方式依赖，会导致其他Transform或者Proguard找不到这些类

--- a/projects/test/gradle-plugin-agp-compat-test/test_JDK17.sh
+++ b/projects/test/gradle-plugin-agp-compat-test/test_JDK17.sh
@@ -14,8 +14,10 @@ source ./test_prepare.sh
 # AGP release页面：https://developer.android.com/studio/releases/gradle-plugin
 # AGP Maven仓库：https://mvnrepository.com/artifact/com.android.tools.build/gradle
 # Gradle下载：https://services.gradle.org/distributions/
+setGradleVersion 8.6
+testUnderAGPVersion 8.4.0-rc02
 setGradleVersion 8.4
-testUnderAGPVersion 8.3.0-alpha16
+testUnderAGPVersion 8.3.2
 setGradleVersion 8.2.1
 testUnderAGPVersion 8.2.0
 setGradleVersion 8.0.2

--- a/projects/test/gradle-plugin-agp-compat-test/test_prepare.sh
+++ b/projects/test/gradle-plugin-agp-compat-test/test_prepare.sh
@@ -23,6 +23,6 @@ function testUnderAGPVersion() {
   local TestAGPVersion=$1
   rm -rf stub-project/build
 
-  echo ./gradlew -PSetGradleVersion=false -PTestAGPVersion=$TestAGPVersion -PShadowVersion=$ShadowVersion :stub-project:assemblePluginA1B2Debug
-  ./gradlew -PSetGradleVersion=false -PTestAGPVersion=$TestAGPVersion -PShadowVersion=$ShadowVersion :stub-project:assemblePluginA1B2Debug
+  echo ./gradlew -PSetGradleVersion=false -PTestAGPVersion=$TestAGPVersion -PShadowVersion=$ShadowVersion :stub-project:packageA1B2DebugPlugin
+  ./gradlew -PSetGradleVersion=false -PTestAGPVersion=$TestAGPVersion -PShadowVersion=$ShadowVersion :stub-project:packageA1B2DebugPlugin
 }


### PR DESCRIPTION
由于兼容性测试此前没有测试packagePlugin部分，导致此问题没有及时暴露。
此提交同时补充了兼容性测试。

更新AGP兼容性测试到8.4.0-rc02版本。

fix #1306