### PR TITLE
build(core.gradle-plugin): Maven发布添加Plugin Marker构件

### DIFF
--- a/buildScripts/gradle/maven.gradle
+++ b/buildScripts/gradle/maven.gradle
@@ -126,6 +126,22 @@ publishing {
                 setScm(scm)
             }
         }
+        // Plugin Marker Artifacts
+        // https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_markers
+        pluginMarker(MavenPublication) {
+            def pluginId = 'com.tencent.shadow.plugin'
+            groupId pluginId
+            artifactId pluginId + '.gradle.plugin'
+            version publicationVersion
+
+            pom.withXml {
+                def root = asNode()
+                def dependencies = root.appendNode('dependencies')
+                dependencies.append(getDependencyNode('compile', coreGroupId, 'gradle-plugin', publicationVersion))
+                def scm = root.appendNode('scm')
+                setScm(scm)
+            }
+        }
         manifestParser(MavenPublication) {
             groupId coreGroupId
             artifactId 'manifest-parser'

--- a/projects/test/gradle-plugin-agp-compat-test/settings.gradle
+++ b/projects/test/gradle-plugin-agp-compat-test/settings.gradle
@@ -1,3 +1,14 @@
+pluginManagement {
+    repositories {
+        if (!System.getenv().containsKey("DISABLE_TENCENT_MAVEN_MIRROR")) {
+            maven { url 'https://mirrors.tencent.com/nexus/repository/maven-public/' }
+        } else {
+            google()
+            mavenCentral()
+        }
+        mavenLocal()
+    }
+}
 rootProject.name = 'gradle-plugin-agp-compat-test'
 if (SetGradleVersion != 'true') {
     include 'stub-project'

--- a/projects/test/gradle-plugin-agp-compat-test/stub-project/build.gradle
+++ b/projects/test/gradle-plugin-agp-compat-test/stub-project/build.gradle
@@ -23,9 +23,15 @@ buildscript {
         classpath "com.tencent.shadow.core:gradle-plugin:$ShadowVersion"
     }
 }
-
-apply plugin: 'com.android.application'
-apply plugin: 'com.tencent.shadow.plugin'
+try {
+    plugins {
+        id 'com.android.application' version "$TestAGPVersion" apply true
+        id 'com.tencent.shadow.plugin' version "$ShadowVersion" apply true
+    }
+} catch (Exception ignored) {
+    apply plugin: 'com.android.application'
+    apply plugin: 'com.tencent.shadow.plugin'
+}
 
 allprojects {
     repositories {


### PR DESCRIPTION
便于插件工程以Gradle更新的plugins id语法引入插件。
plugins {
    id 'com.tencent.shadow.plugin'
}

此PR为重提 #1319
