### PR TITLE
fix(core.gradle-plugin): 修复在 Windows 平台连续 gradle clean 打包失败的问题

### DIFF
--- a/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransform.kt
+++ b/projects/sdk/core/transform-kit/src/main/kotlin/com/tencent/shadow/core/transform_kit/AbstractTransform.kt
@@ -74,7 +74,17 @@ abstract class AbstractTransform(
         //CtClass在编辑后，其对象中的各种信息，比如superClass并没有更新。
         //所以需要重新创建一个ClassPool，加载转换后的类，用于各种转换后的检查。
         val debugClassPool = classPoolBuilder.build()
-        debugClassPool.appendClassPath(mDebugClassJar.absolutePath)
+        java.util.jar.JarFile(mDebugClassJar).use { jarFile ->
+            jarFile.entries().iterator().forEach { entry ->
+                if (!entry.name.endsWith(".class")) {
+                    return@forEach
+                }
+                jarFile.getInputStream(entry).use {
+                    // 直接从流创建 CtClass
+                    debugClassPool.makeClass(it)
+                }
+            }
+        }
         val inputClassNames = allInputCtClass.map { it.name }
         onCheckTransformedClasses(debugClassPool, inputClassNames)
     }


### PR DESCRIPTION
transform-temp.jar 文件被新创建的 ClassPool 持有访问且没有释放，导致在 Windows 环境下 gradle clean 无法删除 transform-temp.jar 。新的方案是基于 IO 流读取 transform-temp.jar 文件中的 class 文件，并创建 CtClass 导入 ClassPool 中，避免 ClassPool 对 transform-temp.jar 文件持有访问。