### PR TITLE
feat(core.runtime): 支持Content Provider设置multiprocess="true"

### DIFF
--- a/projects/sdk/core/common/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerContentProvider.java
+++ b/projects/sdk/core/common/src/main/java/com/tencent/shadow/core/runtime/container/PluginContainerContentProvider.java
@@ -38,6 +38,10 @@ public class PluginContainerContentProvider extends ContentProvider {
 
 
     public PluginContainerContentProvider() {
+        ContentProviderDelegateProvider p = ContentProviderDelegateProviderHolder.contentProviderDelegateProvider;
+        if (p != null) {
+            hostContentProviderDelegate = p.getHostContentProviderDelegate();
+        }
         ContentProviderDelegateProviderHolder.setDelegateProviderHolderPrepareListener(new ContentProviderDelegateProviderHolder.DelegateProviderHolderPrepareListener() {
             @Override
             public void onPrepare() {


### PR DESCRIPTION
当 multiprocess="true" 时，PluginContainerContentProvider 不会在 Application.onCreate 之前创建，而是在真正被调用时才会创建。

当 PluginContainerContentProvider.onCreate 被调用时，DelegateProviderHolderPrepareListener.onPrepare() 方法已经调用（在 DynamicPluginLoader.<init> 方法中），导致 PluginContainerContentProvider.hostContentProviderDelegate 没有被赋值。