### PR TITLE
feat(core.runtime): 支持Content Provider多authority功能

### DIFF
--- a/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/managers/ComponentManager.kt
+++ b/projects/sdk/core/loader/src/main/kotlin/com/tencent/shadow/core/loader/managers/ComponentManager.kt
@@ -60,6 +60,13 @@ abstract class ComponentManager : PluginComponentLauncher {
 
     abstract fun onBindContainerContentProvider(pluginContentProvider: ComponentName): ContainerProviderInfo
 
+    open fun onBindContainerContentProvider(
+        pluginContentProvider: ComponentName,
+        pluginAuthority: String
+    ): ContainerProviderInfo {
+        return onBindContainerContentProvider(pluginContentProvider)
+    }
+
     override fun startActivity(
         shadowContext: ShadowContext,
         pluginIntent: Intent,
@@ -212,11 +219,16 @@ abstract class ComponentManager : PluginComponentLauncher {
 
         pluginManifest.providers?.forEach {
             val componentName = ComponentName(applicationPackageName, it.className)
-            mPluginContentProviderManager!!.addContentProviderInfo(
-                loadParameters.partKey,
-                it,
-                onBindContainerContentProvider(componentName)
-            )
+            it.authorities.split(";")
+                .filter { authority -> authority.isNotBlank() }
+                .forEach { authority ->
+                    mPluginContentProviderManager!!.addContentProviderInfo(
+                        loadParameters.partKey,
+                        it,
+                        onBindContainerContentProvider(componentName, authority),
+                        authority
+                    )
+                }
         }
 
         pluginManifest.receivers?.forEach {


### PR DESCRIPTION
[Content Provider 支持多个 authority ，使用英文 ; 进行分割](https://developer.android.com/guide/topics/manifest/provider-element#auth)。

当插件 Content Provider 使用该功能时，没有对 authorities 进行拆分，导致任意 authority 都命中失败。